### PR TITLE
Add snapcraft.yaml (support snap packaging).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # dnsperf
 
+[![Snap Status](https://build.snapcraft.io/badge/mpontillo/dnsperf.svg)](https://build.snapcraft.io/user/mpontillo/dnsperf)
+
 ## Overview
 
 [https://github.com/nominum/dnsperf](https://github.com/nominum/dnsperf)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,67 @@
+name: dnsperf
+# printf "version: '%s'\n" $(cat version.h | grep 'define VER' | cut -d\" -f 2)
+version: '2.1.1.0.d'
+summary: Tools to gather DNS latency and throughput metrics.
+description: |
+  DNSPerf and ResPerf are free tools developed by Nominum that make it simple
+  to gather accurate latency and throughput metrics for Domain Name Service
+  (DNS). These tools are easy-to-use and simulate typical Internet so network
+  operators can benchmark their naming and addressing infrastructure and plan
+  for upgrades. The latest version of the DNSPerf and ResPerf can be used with
+  test files that include IPv6 queries.
+  
+  DNSPerf "self-paces" the DNS query load to simulate network conditions. New
+  features in DNSPerf improve the precision of latency measurements and allow
+  for per packet per-query latency reporting is possible. DNSPerf is now
+  multithreaded, multiple DNSPerf clients can be supported in multicore
+  systems (each client requires two cores). The output of DNSPerf has also
+  been improved so it is more concise and useful. Latency data can be used to
+  make detailed graphs so it is simple for network operators to take advantage
+  of the data.
+  
+  ResPerf systematically increases the query rate and monitors the response
+  rate to simulate caching DNS services.
+  
+  Sample data files can be found at:
+      ftp://ftp.nominum.com/pub/nominum/dnsperf/data/
+
+grade: devel
+confinement: devmode
+
+
+apps:
+  dnsperf:
+    command: dnsperf
+    plugs:
+     - home
+  resperf:
+    command: resperf
+    plugs:
+     - home
+  resperf-report:
+    command: resperf-report
+    plugs:
+     - home
+
+parts:
+  dnsperf:
+    # See 'snapcraft plugins'
+    plugin: autotools
+    source: https://github.com/mpontillo/dnsperf
+    source-type: git
+    source-tag: master
+    build-packages: 
+     - build-essential
+     - libbind-dev
+     - libkrb5-dev
+     - libssl-dev
+     - libcap-dev
+     - libxml2-dev
+     - libgeoip-dev
+    stage-packages:
+     - bind9utils
+     - libbind9-140
+     - libkrb5support0
+     - libssl1.0.0
+     - libxml2
+     - libgeoip1


### PR DESCRIPTION
This isn't ready to merge yet, but I wanted to put this out for comments.

I wanted to run `dnsperf` on Ubuntu, and after finding [this gist](https://gist.github.com/i0rek/369a6bcd172e214fd791), I thought I'd try creating a `snap` for it.

I've registered the `dnsperf` name for the moment in order to publish the snap, If Nominum would like to maintain the snap, I believe there is a way to transfer ownership.

Things that should happen before this merges:
* Remove `mpontillo` from github URL in `snapcraft.yaml` (used for publishing).
* Nominum should take ownership of the `dnsperf` name and build the snap on the [snapcraft builder](https://build.snapcraft.io/).
* The version in `snapcraft.yaml` should be automatically determined from the source code (such as per the script snippet). I'm not sure how that works with automated CI, given the apparent chicken-and-egg problem there.
* Consider including the sample query data in the snap.
* Take a closer look at permissions so that the confinement can be increased.

To test this, you can do the following on a recent Ubuntu release (such as 16.04 "Xenial"):

    snap install --devmode --beta dnsperf

In order to enable strict confinement, the snap should be tested in jail mode, such as by installing it like this:

    snap install --jailmode --beta dnsperf

However, in order for this to work, the snap will need to get the appropriate permissions. Currently it raises errors such as:

    ../../../../lib/isc/unix/net.c:151: socket() failed: Permission denied
    ../../../../lib/isc/unix/net.c:151: socket() failed: Permission denied
    Error: socket: Permission denied

That said, given that this tool does not seem to change very much, I'm happy to continue publishing the snap myself for now.