### PR TITLE
send periodic stats to stderr

### DIFF
--- a/dnsperf.c
+++ b/dnsperf.c
@@ -937,9 +937,7 @@ do_interval_stats(void *arg)
         interval_time = now - last_interval_time;
         num_completed = total.num_completed - last_completed;
         qps = num_completed / (((double)interval_time) / MILLION);
-        perf_log_printf("%u.%06u: %.6lf",
-                        (unsigned int)(now / MILLION),
-                        (unsigned int)(now % MILLION), qps);
+        perf_log_sameline("qps: %.6lf", qps);
         last_interval_time = now;
         last_completed = total.num_completed;
     }

--- a/log.c
+++ b/log.c
@@ -25,15 +25,23 @@
 pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void
-vlog(FILE *stream, const char *prefix, const char *fmt, va_list args)
+vlog(FILE *stream, const char *prefix, const char term, const char *fmt, va_list args)
 {
     LOCK(&log_lock);
     fflush(stdout);
     if (prefix != NULL)
         fprintf(stream, "%s: ", prefix);
     vfprintf(stream, fmt, args);
-    fprintf(stream, "\n");
+    fprintf(stream, "%c", term);
     UNLOCK(&log_lock);
+}
+
+void
+perf_log_sameline(const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    vlog(stderr, NULL, '\r', fmt, args);
 }
 
 void
@@ -41,7 +49,7 @@ perf_log_printf(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    vlog(stdout, NULL, fmt, args);
+    vlog(stdout, NULL, '\n', fmt, args);
 }
 
 void
@@ -49,7 +57,7 @@ perf_log_fatal(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    vlog(stderr, "Error", fmt, args);
+    vlog(stderr, "Error", '\n', fmt, args);
     exit(1);
 }
 
@@ -58,5 +66,5 @@ perf_log_warning(const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    vlog(stderr, "Warning", fmt, args);
+    vlog(stderr, "Warning", '\n', fmt, args);
 }

--- a/log.h
+++ b/log.h
@@ -26,4 +26,7 @@ perf_log_fatal(const char *fmt, ...);
 void
 perf_log_warning(const char *fmt, ...);
 
+void
+perf_log_sameline(const char *fmt, ...);
+
 #endif


### PR DESCRIPTION
This lets you watch stats and redirect normal output to a file without logging all the periodic stats.