### PR TITLE
Fix build with bind >= 9.13.3

### DIFF
--- a/datafile.c
+++ b/datafile.c
@@ -15,6 +15,7 @@
  */
 
 #include <fcntl.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -37,14 +38,14 @@ struct perf_datafile {
     pthread_mutex_t lock;
     int pipe_fd;
     int fd;
-    isc_boolean_t is_file;
+    bool is_file;
     size_t size;
-    isc_boolean_t cached;
+    bool cached;
     char databuf[BUFFER_SIZE + 1];
     isc_buffer_t data;
     unsigned int maxruns;
     unsigned int nruns;
-    isc_boolean_t read_any;
+    bool read_any;
 };
 
 static inline void
@@ -69,12 +70,12 @@ perf_datafile_open(isc_mem_t *mctx, const char *filename)
     dfile->mctx = mctx;
     MUTEX_INIT(&dfile->lock);
     dfile->pipe_fd = -1;
-    dfile->is_file = ISC_FALSE;
+    dfile->is_file = false;
     dfile->size = 0;
-    dfile->cached = ISC_FALSE;
+    dfile->cached = false;
     dfile->maxruns = 1;
     dfile->nruns = 0;
-    dfile->read_any = ISC_FALSE;
+    dfile->read_any = false;
     isc_buffer_init(&dfile->data, dfile->databuf, BUFFER_SIZE);
     if (filename == NULL) {
         dfile->fd = STDIN_FILENO;
@@ -83,7 +84,7 @@ perf_datafile_open(isc_mem_t *mctx, const char *filename)
         if (dfile->fd < 0)
             perf_log_fatal("unable to open file: %s", filename);
         if (fstat(dfile->fd, &buf) == 0 && S_ISREG(buf.st_mode)) {
-            dfile->is_file = ISC_TRUE;
+            dfile->is_file = true;
             dfile->size = buf.st_size;
         }
     }
@@ -159,7 +160,7 @@ read_more(perf_datafile_t *dfile)
     nul_terminate(dfile);
 
     if (dfile->is_file && isc_buffer_usedlength(&dfile->data) == dfile->size)
-        dfile->cached = ISC_TRUE;
+        dfile->cached = true;
 
     return (ISC_R_SUCCESS);
 }
@@ -171,7 +172,7 @@ read_one_line(perf_datafile_t *dfile, isc_buffer_t *lines)
     unsigned int length, curlen, nrem;
     isc_result_t result;
 
-    while (ISC_TRUE) {
+    while (true) {
         /* Get the current line */
         cur = isc_buffer_current(&dfile->data);
         curlen = strcspn(cur, "\n");
@@ -216,7 +217,7 @@ read_one_line(perf_datafile_t *dfile, isc_buffer_t *lines)
 
 isc_result_t
 perf_datafile_next(perf_datafile_t *dfile, isc_buffer_t *lines,
-                   isc_boolean_t is_update)
+                   bool is_update)
 {
     const char *current;
     isc_result_t result;
@@ -243,10 +244,10 @@ perf_datafile_next(perf_datafile_t *dfile, isc_buffer_t *lines,
     if (result != ISC_R_SUCCESS) {
         goto done;
     }
-    dfile->read_any = ISC_TRUE;
+    dfile->read_any = true;
 
     if (is_update) {
-        while (ISC_TRUE) {
+        while (true) {
             current = isc_buffer_used(lines);
             result = read_one_line(dfile, lines);
             if (result == ISC_R_EOF && dfile->maxruns != dfile->nruns) {

--- a/datafile.h
+++ b/datafile.h
@@ -17,6 +17,8 @@
 #ifndef PERF_DATAFILE_H
 #define PERF_DATAFILE_H 1
 
+#include <stdbool.h>
+
 #include <isc/types.h>
 
 typedef struct perf_datafile perf_datafile_t;
@@ -35,7 +37,7 @@ perf_datafile_setpipefd(perf_datafile_t *dfile, int pipe_fd);
 
 isc_result_t
 perf_datafile_next(perf_datafile_t *dfile, isc_buffer_t *lines,
-                   isc_boolean_t is_update);
+                   bool is_update);
 
 unsigned int
 perf_datafile_nruns(const perf_datafile_t *dfile);

--- a/dns.c
+++ b/dns.c
@@ -17,6 +17,7 @@
 #include <ctype.h>
 #include <time.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -108,7 +109,7 @@ struct perf_dnsctx {
 };
 
 perf_dnsctx_t *
-perf_dns_createctx(isc_boolean_t updates)
+perf_dns_createctx(bool updates)
 {
     isc_mem_t *mctx;
     perf_dnsctx_t *ctx;
@@ -359,7 +360,7 @@ perf_dns_destroyednsoption(perf_dnsednsoption_t **optionp)
  * Appends an OPT record to the packet.
  */
 static isc_result_t
-add_edns(isc_buffer_t *packet, isc_boolean_t dnssec,
+add_edns(isc_buffer_t *packet, bool dnssec,
          perf_dnsednsoption_t *option)
 {
     unsigned char *base;
@@ -596,7 +597,7 @@ build_query(const isc_textregion_t *line, isc_buffer_t *msg)
     return ISC_R_SUCCESS;
 }
 
-static isc_boolean_t
+static bool
 token_equals(const isc_textregion_t *token, const char *str)
 {
     return (strlen(str) == token->length &&
@@ -712,7 +713,7 @@ build_update(perf_dnsctx_t *ctx, const isc_textregion_t *record,
     unsigned char rdataarray[MAX_RDATA_LENGTH];
     isc_textregion_t token;
     char *str;
-    isc_boolean_t is_update;
+    bool is_update;
     int updates = 0;
     int prereqs = 0;
     dns_fixedname_t fzname, foname;
@@ -753,7 +754,7 @@ build_update(perf_dnsctx_t *ctx, const isc_textregion_t *record,
     isc_buffer_putuint16(msg, dns_rdatatype_soa);
     isc_buffer_putuint16(msg, dns_rdataclass_in);
 
-    while (ISC_TRUE) {
+    while (true) {
         input.base += strlen(input.base) + 1;
         if (input.base >= record->base + record->length) {
             perf_log_warning("warning: incomplete update");
@@ -766,7 +767,7 @@ build_update(perf_dnsctx_t *ctx, const isc_textregion_t *record,
         dns_rdata_init(&rdata);
         rdlen = 0;
         rdclass = dns_rdataclass_in;
-        is_update = ISC_FALSE;
+        is_update = false;
 
         token.base = input.base;
         token.length = strcspn(token.base, WHITESPACE);
@@ -775,38 +776,38 @@ build_update(perf_dnsctx_t *ctx, const isc_textregion_t *record,
             break;
         } else if (token_equals(&token, "add")) {
             result = read_update_line(ctx, &input, str, zname,
-                                      ISC_TRUE, ISC_TRUE, ISC_TRUE,
-                                      ISC_TRUE, oname, &ttl, &rdtype,
+                                      true, true, true,
+                                      true, oname, &ttl, &rdtype,
                                       &rdata, &rdatabuf);
             rdclass = dns_rdataclass_in;
-            is_update = ISC_TRUE;
+            is_update = true;
         } else if (token_equals(&token, "delete")) {
             result = read_update_line(ctx, &input, str, zname,
-                                      ISC_FALSE, ISC_FALSE, ISC_TRUE,
-                                      ISC_FALSE, oname, &ttl,
+                                      false, false, true,
+                                      false, oname, &ttl,
                                       &rdtype, &rdata, &rdatabuf);
             if (isc_buffer_usedlength(&rdatabuf) > 0)
                 rdclass = dns_rdataclass_none;
             else
                 rdclass = dns_rdataclass_any;
-            is_update = ISC_TRUE;
+            is_update = true;
         } else if (token_equals(&token, "require")) {
             result = read_update_line(ctx, &input, str, zname,
-                                      ISC_FALSE, ISC_FALSE, ISC_TRUE,
-                                      ISC_FALSE, oname, &ttl,
+                                      false, false, true,
+                                      false, oname, &ttl,
                                       &rdtype, &rdata, &rdatabuf);
             if (isc_buffer_usedlength(&rdatabuf) > 0)
                 rdclass = dns_rdataclass_in;
             else
                 rdclass = dns_rdataclass_any;
-            is_update = ISC_FALSE;
+            is_update = false;
         } else if (token_equals(&token, "prohibit")) {
             result = read_update_line(ctx, &input, str, zname,
-                                      ISC_FALSE, ISC_FALSE, ISC_FALSE,
-                                      ISC_FALSE, oname, &ttl,
+                                      false, false, false,
+                                      false, oname, &ttl,
                                       &rdtype, &rdata, &rdatabuf);
             rdclass = dns_rdataclass_none;
-            is_update = ISC_FALSE;
+            is_update = false;
         } else {
             perf_log_warning("invalid update command: %s", input.base);
             result = ISC_R_FAILURE;
@@ -868,7 +869,7 @@ done:
 isc_result_t
 perf_dns_buildrequest(perf_dnsctx_t *ctx, const isc_textregion_t *record,
                       uint16_t qid,
-                      isc_boolean_t edns, isc_boolean_t dnssec,
+                      bool edns, bool dnssec,
                       perf_dnstsigkey_t *tsigkey, perf_dnsednsoption_t *option,
                       isc_buffer_t *msg)
 {

--- a/dns.c
+++ b/dns.c
@@ -16,6 +16,7 @@
 
 #include <ctype.h>
 #include <time.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -291,7 +292,7 @@ perf_dns_parseednsoption(const char *arg, isc_mem_t *mctx)
     char *sep;
     char *value;
     perf_dnsednsoption_t *option;
-    isc_uint16_t code;
+    uint16_t code;
     isc_buffer_t save;
     isc_result_t result;
 
@@ -494,7 +495,7 @@ add_tsig(isc_buffer_t *packet, perf_dnstsigkey_t *tsigkey)
     unsigned int rdlen, totallen;
     unsigned char tmpdata[512];
     isc_buffer_t tmp;
-    isc_uint32_t now;
+    uint32_t now;
     unsigned char digest[ISC_SHA256_DIGESTLENGTH];
 
     hmac_init(tsigkey, &hmac);
@@ -609,7 +610,7 @@ static isc_result_t
 read_update_line(perf_dnsctx_t *ctx, const isc_textregion_t *line, char *str,
                  dns_name_t *zname, int want_ttl, int need_type,
                  int want_rdata, int need_rdata, dns_name_t *name,
-                 isc_uint32_t *ttlp, dns_rdatatype_t *typep,
+                 uint32_t *ttlp, dns_rdatatype_t *typep,
                  dns_rdata_t *rdata, isc_buffer_t *rdatabuf)
 {
     char *curr_str;
@@ -716,11 +717,11 @@ build_update(perf_dnsctx_t *ctx, const isc_textregion_t *record,
     int prereqs = 0;
     dns_fixedname_t fzname, foname;
     dns_name_t *zname, *oname;
-    isc_uint32_t ttl;
+    uint32_t ttl;
     dns_rdatatype_t rdtype;
     dns_rdataclass_t rdclass;
     dns_rdata_t rdata;
-    isc_uint16_t rdlen;
+    uint16_t rdlen;
     isc_result_t result;
 
     /* Reset compression context */
@@ -866,7 +867,7 @@ done:
 
 isc_result_t
 perf_dns_buildrequest(perf_dnsctx_t *ctx, const isc_textregion_t *record,
-                      isc_uint16_t qid,
+                      uint16_t qid,
                       isc_boolean_t edns, isc_boolean_t dnssec,
                       perf_dnstsigkey_t *tsigkey, perf_dnsednsoption_t *option,
                       isc_buffer_t *msg)

--- a/dns.h
+++ b/dns.h
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <inttypes.h>
+
 #include <isc/types.h>
 
 #ifndef PERF_DNS_H
@@ -48,7 +50,7 @@ perf_dns_destroyctx(perf_dnsctx_t **ctxp);
 
 isc_result_t
 perf_dns_buildrequest(perf_dnsctx_t *ctx, const isc_textregion_t *record,
-                      isc_uint16_t qid,
+                      uint16_t qid,
                       isc_boolean_t edns, isc_boolean_t dnssec,
                       perf_dnstsigkey_t *tsigkey,
                       perf_dnsednsoption_t *edns_option, isc_buffer_t *msg);

--- a/dns.h
+++ b/dns.h
@@ -15,6 +15,7 @@
  */
 
 #include <inttypes.h>
+#include <stdbool.h>
 
 #include <isc/types.h>
 
@@ -43,7 +44,7 @@ void
 perf_dns_destroyednsoption(perf_dnsednsoption_t **optionp);
 
 perf_dnsctx_t *
-perf_dns_createctx(isc_boolean_t updates);
+perf_dns_createctx(bool updates);
 
 void
 perf_dns_destroyctx(perf_dnsctx_t **ctxp);
@@ -51,7 +52,7 @@ perf_dns_destroyctx(perf_dnsctx_t **ctxp);
 isc_result_t
 perf_dns_buildrequest(perf_dnsctx_t *ctx, const isc_textregion_t *record,
                       uint16_t qid,
-                      isc_boolean_t edns, isc_boolean_t dnssec,
+                      bool edns, bool dnssec,
                       perf_dnstsigkey_t *tsigkey,
                       perf_dnsednsoption_t *edns_option, isc_buffer_t *msg);
 

--- a/dnsperf.c
+++ b/dnsperf.c
@@ -18,6 +18,8 @@
  ***    DNS Performance Testing Tool
  ***/
 
+#include <inttypes.h>
+
 #include <errno.h>
 #include <math.h>
 #include <pthread.h>
@@ -260,16 +262,17 @@ print_statistics(const config_t *config, const times_t *times, stats_t *stats)
 
     printf("Statistics:\n\n");
 
-    printf("  %s sent:         %" ISC_PRINT_QUADFORMAT "u\n",
+    printf("  %s sent:         %" PRIu64 "\n",
            units, stats->num_sent);
-    printf("  %s completed:    %" ISC_PRINT_QUADFORMAT "u (%.2lf%%)\n",
+    printf("  %s completed:    %" PRIu64 " (%.2lf%%)\n",
            units, stats->num_completed,
            SAFE_DIV(100.0 * stats->num_completed, stats->num_sent));
-    printf("  %s lost:         %" ISC_PRINT_QUADFORMAT "u (%.2lf%%)\n",
+    printf("  %s lost:         %" PRIu64 " (%.2lf%%)\n",
            units, stats->num_timedout,
            SAFE_DIV(100.0 * stats->num_timedout, stats->num_sent));
     if (stats->num_interrupted > 0)
-        printf("  %s interrupted:  %" ISC_PRINT_QUADFORMAT "u (%.2lf%%)\n",
+        printf("  %s interrupted:  %" PRIu64 " "
+               "(%.2lf%%)\n",
                units, stats->num_interrupted,
                SAFE_DIV(100.0 * stats->num_interrupted, stats->num_sent));
     printf("\n");
@@ -283,7 +286,7 @@ print_statistics(const config_t *config, const times_t *times, stats_t *stats)
             first_rcode = ISC_FALSE;
         else
             printf(", ");
-        printf("%s %" ISC_PRINT_QUADFORMAT "u (%.2lf%%)",
+        printf("%s %" PRIu64 " (%.2lf%%)",
                perf_dns_rcode_strings[i], stats->rcodecounts[i],
                (stats->rcodecounts[i] * 100.0) / stats->num_completed);
     }

--- a/dnsperf.c
+++ b/dnsperf.c
@@ -23,6 +23,7 @@
 #include <math.h>
 #include <pthread.h>
 #include <signal.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -82,15 +83,15 @@ typedef struct {
     isc_sockaddr_t local_addr;
     uint64_t timeout;
     uint32_t bufsize;
-    isc_boolean_t edns;
-    isc_boolean_t dnssec;
+    bool edns;
+    bool dnssec;
     perf_dnstsigkey_t *tsigkey;
     perf_dnsednsoption_t *edns_option;
     uint32_t max_outstanding;
     uint32_t max_qps;
     uint64_t stats_interval;
-    isc_boolean_t updates;
-    isc_boolean_t verbose;
+    bool updates;
+    bool verbose;
 } config_t;
 
 typedef struct {
@@ -150,7 +151,7 @@ typedef struct {
 
     perf_dnsctx_t *dnsctx;
 
-    isc_boolean_t done_sending;
+    bool done_sending;
     uint64_t done_send_time;
 
     const config_t *config;
@@ -167,9 +168,9 @@ static threadinfo_t *threads;
 
 static pthread_mutex_t start_lock = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t start_cond = PTHREAD_COND_INITIALIZER;
-static isc_boolean_t started;
+static bool started;
 
-static isc_boolean_t interrupted = ISC_FALSE;
+static bool interrupted = false;
 
 static int threadpipe[2];
 static int mainpipe[2];
@@ -251,7 +252,7 @@ print_statistics(const config_t *config, const times_t *times, stats_t *stats)
 {
     const char *units;
     uint64_t run_time;
-    isc_boolean_t first_rcode;
+    bool first_rcode;
     uint64_t latency_avg;
     unsigned int i;
 
@@ -277,12 +278,12 @@ print_statistics(const config_t *config, const times_t *times, stats_t *stats)
     printf("\n");
 
     printf("  Response codes:       ");
-    first_rcode = ISC_TRUE;
+    first_rcode = true;
     for (i = 0; i < 16; i++) {
         if (stats->rcodecounts[i] == 0)
             continue;
         if (first_rcode)
-            first_rcode = ISC_FALSE;
+            first_rcode = false;
         else
             printf(", ");
         printf("%s %" PRIu64 " (%.2lf%%)",
@@ -464,7 +465,7 @@ setup(int argc, char **argv, config_t *config)
     perf_datafile_setmaxruns(input, config->maxruns);
 
     if (config->dnssec || edns_option != NULL)
-        config->edns = ISC_TRUE;
+        config->edns = true;
 
     if (tsigkey != NULL)
         config->tsigkey = perf_dns_parsetsigkey(tsigkey, mctx);
@@ -668,7 +669,7 @@ do_send(void *arg)
         stats->total_request_size += length;
     }
     tinfo->done_send_time = get_time();
-    tinfo->done_sending = ISC_TRUE;
+    tinfo->done_sending = true;
     write(mainpipe[1], "", 1);
     return NULL;
 }
@@ -715,12 +716,12 @@ typedef struct {
     unsigned int size;
     uint64_t when;
     uint64_t sent;
-    isc_boolean_t unexpected;
-    isc_boolean_t short_response;
+    bool unexpected;
+    bool short_response;
     char *desc;
 } received_query_t;
 
-static isc_boolean_t
+static bool
 recv_one(threadinfo_t *tinfo, int which_sock,
          unsigned char *packet_buffer, unsigned int packet_size,
          received_query_t *recvd, int *saved_errnop)
@@ -737,7 +738,7 @@ recv_one(threadinfo_t *tinfo, int which_sock,
     now = get_time();
     if (n < 0) {
         *saved_errnop = errno;
-        return ISC_FALSE;
+        return false;
     }
     recvd->sock = s;
     recvd->qid = ntohs(packet_header[0]);
@@ -745,10 +746,10 @@ recv_one(threadinfo_t *tinfo, int which_sock,
     recvd->size = n;
     recvd->when = now;
     recvd->sent = 0;
-    recvd->unexpected = ISC_FALSE;
+    recvd->unexpected = false;
     recvd->short_response = ISC_TF(n < 4);
     recvd->desc = NULL;
-    return ISC_TRUE;
+    return true;
 }
 
 static inline void
@@ -762,7 +763,7 @@ bit_set(unsigned char *bits, unsigned int bit)
     bits[bit / 8] |= mask;
 }
 
-static inline isc_boolean_t
+static inline bool
 bit_check(unsigned char *bits, unsigned int bit)
 {
     unsigned int shift;
@@ -770,8 +771,8 @@ bit_check(unsigned char *bits, unsigned int bit)
     shift = 7 - (bit % 8);
 
     if ((bits[bit / 8] >> shift) & 0x01)
-        return ISC_TRUE;
-    return ISC_FALSE;
+        return true;
+    return false;
 }
 
 static void *
@@ -842,7 +843,7 @@ do_recv(void *arg)
                 q->timestamp == UINT64_MAX ||
                 q->sock != recvd[i].sock)
             {
-                recvd[i].unexpected = ISC_TRUE;
+                recvd[i].unexpected = true;
                 continue;
             }
             query_move(tinfo, q, append_unused);
@@ -954,7 +955,7 @@ cancel_queries(threadinfo_t *tinfo)
 {
     struct query_info *q;
 
-    while (ISC_TRUE) {
+    while (true) {
         q = ISC_LIST_TAIL(tinfo->outstanding_queries);
         if (q == NULL)
             break;
@@ -1085,7 +1086,7 @@ main(int argc, char **argv)
 
     perf_datafile_setpipefd(input, threadpipe[0]);
 
-    perf_os_blocksignal(SIGINT, ISC_TRUE);
+    perf_os_blocksignal(SIGINT, true);
 
     print_initial_status(&config);
 
@@ -1109,16 +1110,16 @@ main(int argc, char **argv)
     times.stop_time_ns.tv_nsec = (times.stop_time % MILLION) * 1000;
 
     LOCK(&start_lock);
-    started = ISC_TRUE;
+    started = true;
     BROADCAST(&start_cond);
     UNLOCK(&start_lock);
 
     perf_os_handlesignal(SIGINT, handle_sigint);
-    perf_os_blocksignal(SIGINT, ISC_FALSE);
+    perf_os_blocksignal(SIGINT, false);
     result = perf_os_waituntilreadable(mainpipe[0], intrpipe[0],
                                        times.stop_time - times.start_time);
     if (result == ISC_R_CANCELED)
-        interrupted = ISC_TRUE;
+        interrupted = true;
 
     times.end_time = get_time();
 

--- a/dnsperf.c
+++ b/dnsperf.c
@@ -19,7 +19,6 @@
  ***/
 
 #include <inttypes.h>
-
 #include <errno.h>
 #include <math.h>
 #include <pthread.h>
@@ -75,53 +74,53 @@ typedef struct {
     int argc;
     char **argv;
     int family;
-    isc_uint32_t clients;
-    isc_uint32_t threads;
-    isc_uint32_t maxruns;
-    isc_uint64_t timelimit;
+    uint32_t clients;
+    uint32_t threads;
+    uint32_t maxruns;
+    uint64_t timelimit;
     isc_sockaddr_t server_addr;
     isc_sockaddr_t local_addr;
-    isc_uint64_t timeout;
-    isc_uint32_t bufsize;
+    uint64_t timeout;
+    uint32_t bufsize;
     isc_boolean_t edns;
     isc_boolean_t dnssec;
     perf_dnstsigkey_t *tsigkey;
     perf_dnsednsoption_t *edns_option;
-    isc_uint32_t max_outstanding;
-    isc_uint32_t max_qps;
-    isc_uint64_t stats_interval;
+    uint32_t max_outstanding;
+    uint32_t max_qps;
+    uint64_t stats_interval;
     isc_boolean_t updates;
     isc_boolean_t verbose;
 } config_t;
 
 typedef struct {
-    isc_uint64_t start_time;
-    isc_uint64_t end_time;
-    isc_uint64_t stop_time;
+    uint64_t start_time;
+    uint64_t end_time;
+    uint64_t stop_time;
     struct timespec stop_time_ns;
 } times_t;
 
 typedef struct {
-    isc_uint64_t rcodecounts[16];
+    uint64_t rcodecounts[16];
 
-    isc_uint64_t num_sent;
-    isc_uint64_t num_interrupted;
-    isc_uint64_t num_timedout;
-    isc_uint64_t num_completed;
+    uint64_t num_sent;
+    uint64_t num_interrupted;
+    uint64_t num_timedout;
+    uint64_t num_completed;
 
-    isc_uint64_t total_request_size;
-    isc_uint64_t total_response_size;
+    uint64_t total_request_size;
+    uint64_t total_response_size;
 
-    isc_uint64_t latency_sum;
-    isc_uint64_t latency_sum_squares;
-    isc_uint64_t latency_min;
-    isc_uint64_t latency_max;
+    uint64_t latency_sum;
+    uint64_t latency_sum_squares;
+    uint64_t latency_min;
+    uint64_t latency_max;
 } stats_t;
 
 typedef ISC_LIST(struct query_info) query_list;
 
 typedef struct query_info {
-    isc_uint64_t timestamp;
+    uint64_t timestamp;
     query_list *list;
     char *desc;
     int sock;
@@ -152,16 +151,16 @@ typedef struct {
     perf_dnsctx_t *dnsctx;
 
     isc_boolean_t done_sending;
-    isc_uint64_t done_send_time;
+    uint64_t done_send_time;
 
     const config_t *config;
     const times_t *times;
     stats_t stats;
 
-    isc_uint32_t max_outstanding;
-    isc_uint32_t max_qps;
+    uint32_t max_outstanding;
+    uint32_t max_qps;
 
-    isc_uint64_t last_recv;
+    uint64_t last_recv;
 } threadinfo_t;
 
 static threadinfo_t *threads;
@@ -239,7 +238,7 @@ print_final_status(const config_t *config)
 }
 
 static double
-stddev(isc_uint64_t sum_of_squares, isc_uint64_t sum, isc_uint64_t total)
+stddev(uint64_t sum_of_squares, uint64_t sum, uint64_t total)
 {
     double squared;
 
@@ -251,9 +250,9 @@ static void
 print_statistics(const config_t *config, const times_t *times, stats_t *stats)
 {
     const char *units;
-    isc_uint64_t run_time;
+    uint64_t run_time;
     isc_boolean_t first_rcode;
-    isc_uint64_t latency_avg;
+    uint64_t latency_avg;
     unsigned int i;
 
     units = config->updates ? "Updates" : "Queries";
@@ -531,7 +530,7 @@ query_move(threadinfo_t *tinfo, query_info *q, query_move_op op)
     }
 }
 
-static inline isc_uint64_t
+static inline uint64_t
 num_outstanding(const stats_t *stats)
 {
     return stats->num_sent - stats->num_completed - stats->num_timedout;
@@ -555,7 +554,7 @@ do_send(void *arg)
     stats_t *stats;
     unsigned int max_packet_size;
     isc_buffer_t msg;
-    isc_uint64_t now, run_time, req_time;
+    uint64_t now, run_time, req_time;
     char input_data[MAX_INPUT_DATA];
     isc_buffer_t lines;
     isc_region_t used;
@@ -612,7 +611,7 @@ do_send(void *arg)
 
         q = ISC_LIST_HEAD(tinfo->unused_queries);
         query_move(tinfo, q, prepend_outstanding);
-        q->timestamp = ISC_UINT64_MAX;
+        q->timestamp = UINT64_MAX;
         q->sock = tinfo->socks[tinfo->current_sock++ % tinfo->nsocks];
 
         UNLOCK(&tinfo->lock);
@@ -675,7 +674,7 @@ do_send(void *arg)
 }
 
 static void
-process_timeouts(threadinfo_t *tinfo, isc_uint64_t now)
+process_timeouts(threadinfo_t *tinfo, uint64_t now)
 {
     struct query_info *q;
     const config_t *config;
@@ -711,11 +710,11 @@ process_timeouts(threadinfo_t *tinfo, isc_uint64_t now)
 
 typedef struct {
     int sock;
-    isc_uint16_t qid;
-    isc_uint16_t rcode;
+    uint16_t qid;
+    uint16_t rcode;
     unsigned int size;
-    isc_uint64_t when;
-    isc_uint64_t sent;
+    uint64_t when;
+    uint64_t sent;
     isc_boolean_t unexpected;
     isc_boolean_t short_response;
     char *desc;
@@ -726,12 +725,12 @@ recv_one(threadinfo_t *tinfo, int which_sock,
          unsigned char *packet_buffer, unsigned int packet_size,
          received_query_t *recvd, int *saved_errnop)
 {
-    isc_uint16_t *packet_header;
+    uint16_t *packet_header;
     int s;
-    isc_uint64_t now;
+    uint64_t now;
     int n;
 
-    packet_header = (isc_uint16_t *) packet_buffer;
+    packet_header = (uint16_t *) packet_buffer;
 
     s = tinfo->socks[which_sock];
     n = recv(s, packet_buffer, packet_size, 0);
@@ -785,7 +784,7 @@ do_recv(void *arg)
     unsigned int nrecvd;
     int saved_errno;
     unsigned char socketbits[MAX_SOCKETS / 8];
-    isc_uint64_t now, latency;
+    uint64_t now, latency;
     query_info *q;
     unsigned int current_socket, last_socket;
     unsigned int i, j;
@@ -840,7 +839,7 @@ do_recv(void *arg)
 
             q = &tinfo->queries[recvd[i].qid];
             if (q->list != &tinfo->outstanding_queries ||
-                q->timestamp == ISC_UINT64_MAX ||
+                q->timestamp == UINT64_MAX ||
                 q->sock != recvd[i].sock)
             {
                 recvd[i].unexpected = ISC_TRUE;
@@ -919,11 +918,11 @@ do_interval_stats(void *arg)
 {
     threadinfo_t *tinfo;
     stats_t total;
-    isc_uint64_t now;
-    isc_uint64_t last_interval_time;
-    isc_uint64_t last_completed;
-    isc_uint64_t interval_time;
-    isc_uint64_t num_completed;
+    uint64_t now;
+    uint64_t last_interval_time;
+    uint64_t last_completed;
+    uint64_t interval_time;
+    uint64_t num_completed;
     double qps;
 
     tinfo = arg;
@@ -961,7 +960,7 @@ cancel_queries(threadinfo_t *tinfo)
             break;
         query_move(tinfo, q, append_unused);
 
-        if (q->timestamp == ISC_UINT64_MAX)
+        if (q->timestamp == UINT64_MAX)
             continue;
 
         tinfo->stats.num_interrupted++;
@@ -973,10 +972,10 @@ cancel_queries(threadinfo_t *tinfo)
     }
 }
 
-static isc_uint32_t
-per_thread(isc_uint32_t total, isc_uint32_t nthreads, unsigned int offset)
+static uint32_t
+per_thread(uint32_t total, uint32_t nthreads, unsigned int offset)
 {
-    isc_uint32_t value;
+    uint32_t value;
 
     value = total / nthreads;
     if (value % nthreads > offset)
@@ -1105,7 +1104,7 @@ main(int argc, char **argv)
     if (config.timelimit > 0)
         times.stop_time = times.start_time + config.timelimit;
     else
-        times.stop_time = ISC_UINT64_MAX;
+        times.stop_time = UINT64_MAX;
     times.stop_time_ns.tv_sec = times.stop_time / MILLION;
     times.stop_time_ns.tv_nsec = (times.stop_time % MILLION) * 1000;
 

--- a/opt.c
+++ b/opt.c
@@ -15,6 +15,7 @@
  */
 
 #include <getopt.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <inttypes.h>
 #include <stdlib.h>
@@ -43,7 +44,7 @@ typedef struct {
     union {
         void *valp;
         char **stringp;
-        isc_boolean_t *boolp;
+        bool *boolp;
         unsigned int *uintp;
         uint64_t *uint64p;
         double *doublep;
@@ -137,7 +138,7 @@ parse_double(const char *desc, const char *str)
 {
     const char *s;
     char c;
-    isc_boolean_t seen_dot = ISC_FALSE;
+    bool seen_dot = false;
 
     s = str;
     while (*s != 0) {
@@ -145,7 +146,7 @@ parse_double(const char *desc, const char *str)
         if (c == '.') {
             if (seen_dot)
                 goto fail;
-            seen_dot = ISC_TRUE;
+            seen_dot = true;
         } else if (c < '0' || c > '9') {
             goto fail;
         }
@@ -195,7 +196,7 @@ perf_opt_parse(int argc, char **argv)
             *opt->u.stringp = optarg;
             break;
         case perf_opt_boolean:
-            *opt->u.boolp = ISC_TRUE;
+            *opt->u.boolp = true;
             break;
         case perf_opt_uint:
             *opt->u.uintp = parse_uint(opt->desc, optarg,

--- a/opt.c
+++ b/opt.c
@@ -16,6 +16,7 @@
 
 #include <getopt.h>
 #include <stdio.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -44,7 +45,7 @@ typedef struct {
         char **stringp;
         isc_boolean_t *boolp;
         unsigned int *uintp;
-        isc_uint64_t *uint64p;
+        uint64_t *uint64p;
         double *doublep;
         in_port_t *portp;
     } u;
@@ -114,11 +115,11 @@ perf_opt_usage(void)
     }
 }
 
-static isc_uint32_t
+static uint32_t
 parse_uint(const char *desc, const char *str,
            unsigned int min, unsigned int max)
 {
-    isc_uint32_t val;
+    uint32_t val;
     isc_result_t result;
 
     val = 0;
@@ -158,7 +159,7 @@ fail:
     exit(1);
 }
 
-static isc_uint64_t
+static uint64_t
 parse_timeval(const char *desc, const char *str)
 {
     return MILLION * parse_double(desc, str);

--- a/os.c
+++ b/os.c
@@ -17,6 +17,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -30,7 +31,7 @@
 #include "util.h"
 
 void
-perf_os_blocksignal(int sig, isc_boolean_t block)
+perf_os_blocksignal(int sig, bool block)
 {
     sigset_t sset;
     int op;

--- a/os.c
+++ b/os.c
@@ -16,6 +16,7 @@
 
 #include <errno.h>
 #include <signal.h>
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -60,14 +61,14 @@ perf_os_handlesignal(int sig, void (*handler)(int))
 }
 
 isc_result_t
-perf_os_waituntilreadable(int fd, int pipe_fd, isc_int64_t timeout)
+perf_os_waituntilreadable(int fd, int pipe_fd, int64_t timeout)
 {
     return perf_os_waituntilanyreadable(&fd, 1, pipe_fd, timeout);
 }
 
 isc_result_t
 perf_os_waituntilanyreadable(int *fds, unsigned int nfds, int pipe_fd,
-                             isc_int64_t timeout)
+                             int64_t timeout)
 {
     fd_set read_fds;
     unsigned int i;

--- a/os.h
+++ b/os.h
@@ -18,9 +18,10 @@
 #define PERF_OS_H 1
 
 #include <inttypes.h>
+#include <stdbool.h>
 
 void
-perf_os_blocksignal(int sig, isc_boolean_t block);
+perf_os_blocksignal(int sig, bool block);
 
 void
 perf_os_handlesignal(int sig, void (*handler)(int));

--- a/os.h
+++ b/os.h
@@ -17,6 +17,8 @@
 #ifndef PERF_OS_H
 #define PERF_OS_H 1
 
+#include <inttypes.h>
+
 void
 perf_os_blocksignal(int sig, isc_boolean_t block);
 
@@ -24,10 +26,10 @@ void
 perf_os_handlesignal(int sig, void (*handler)(int));
 
 isc_result_t
-perf_os_waituntilreadable(int fd, int pipe_fd, isc_int64_t timeout);
+perf_os_waituntilreadable(int fd, int pipe_fd, int64_t timeout);
 
 isc_result_t
 perf_os_waituntilanyreadable(int *fds, unsigned int nfds, int pipe_fd,
-                             isc_int64_t timeout);
+                             int64_t timeout);
 
 #endif

--- a/resperf.c
+++ b/resperf.c
@@ -19,6 +19,7 @@
  ***/
 
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -89,8 +90,8 @@ static unsigned int nsocks;
 static int *socks;
 
 static uint64_t query_timeout;
-static isc_boolean_t edns;
-static isc_boolean_t dnssec;
+static bool edns;
+static bool dnssec;
 
 static perf_datafile_t *input;
 
@@ -308,7 +309,7 @@ setup(int argc, char **argv)
     input = perf_datafile_open(mctx, filename);
 
     if (dnssec)
-        edns = ISC_TRUE;
+        edns = true;
 
     if (tsigkey_str != NULL)
         tsigkey = perf_dns_parsetsigkey(tsigkey_str, mctx);
@@ -359,7 +360,7 @@ print_statistics(void) {
     int i;
     double max_throughput;
     double loss_at_max_throughput;
-    isc_boolean_t first_rcode;
+    bool first_rcode;
     uint64_t run_time = time_of_end_of_run - time_of_program_start;
 
     printf("\nStatistics:\n\n");
@@ -371,12 +372,12 @@ print_statistics(void) {
     printf("  Queries lost:         %" PRIu64 "\n",
            num_queries_sent - num_responses_received);
     printf("  Response codes:       ");
-    first_rcode = ISC_TRUE;
+    first_rcode = true;
     for (i = 0; i < 16; i++) {
         if (rcodecounts[i] == 0)
             continue;
         if (first_rcode)
-            first_rcode = ISC_FALSE;
+            first_rcode = false;
         else
             printf(", ");
         printf("%s %" PRIu64 " (%.2lf%%)",
@@ -439,7 +440,7 @@ do_one_line(isc_buffer_t *lines, isc_buffer_t *msg) {
     isc_result_t result;
 
     isc_buffer_clear(lines);
-    result = perf_datafile_next(input, lines, ISC_FALSE);
+    result = perf_datafile_next(input, lines, false);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("ran out of query data");
     isc_buffer_usedregion(lines, &used);
@@ -554,7 +555,7 @@ retire_old_queries(void)
 {
     query_info *q;
 
-    while (ISC_TRUE) {
+    while (true) {
         q = ISC_LIST_TAIL(outstanding_list);
         if (q == NULL || (time_now - q->sent_timestamp) < query_timeout)
             break;

--- a/resperf.c
+++ b/resperf.c
@@ -23,6 +23,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <inttypes.h>
 
 #include <sys/time.h>
 
@@ -364,11 +365,11 @@ print_statistics(void) {
 
     printf("\nStatistics:\n\n");
 
-    printf("  Queries sent:         %" ISC_PRINT_QUADFORMAT "u\n",
+    printf("  Queries sent:         %" PRIu64 "\n",
            num_queries_sent);
-    printf("  Queries completed:    %" ISC_PRINT_QUADFORMAT "u\n",
+    printf("  Queries completed:    %" PRIu64 "\n",
            num_responses_received);
-    printf("  Queries lost:         %" ISC_PRINT_QUADFORMAT "u\n",
+    printf("  Queries lost:         %" PRIu64 "\n",
            num_queries_sent - num_responses_received);
     printf("  Response codes:       ");
     first_rcode = ISC_TRUE;
@@ -379,7 +380,7 @@ print_statistics(void) {
             first_rcode = ISC_FALSE;
         else
             printf(", ");
-        printf("%s %" ISC_PRINT_QUADFORMAT "u (%.2lf%%)",
+        printf("%s %" PRIu64 " (%.2lf%%)",
                perf_dns_rcode_strings[i], rcodecounts[i],
                (rcodecounts[i] * 100.0) / num_responses_received);
     }

--- a/resperf.c
+++ b/resperf.c
@@ -23,7 +23,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
-#include <inttypes.h>
 
 #include <sys/time.h>
 
@@ -65,7 +64,7 @@ struct query_info;
 typedef ISC_LIST(struct query_info) query_list;
 
 typedef struct query_info {
-    isc_uint64_t sent_timestamp;
+    uint64_t sent_timestamp;
     /*
      * This link links the query into the list of outstanding
      * queries or the list of available query IDs.
@@ -89,7 +88,7 @@ static isc_sockaddr_t local_addr;
 static unsigned int nsocks;
 static int *socks;
 
-static isc_uint64_t query_timeout;
+static uint64_t query_timeout;
 static isc_boolean_t edns;
 static isc_boolean_t dnssec;
 
@@ -100,24 +99,24 @@ double max_qps = 100000.0;
 
 /* The time period over which we ramp up traffic */
 #define DEFAULT_RAMP_TIME 60
-static isc_uint64_t ramp_time;
+static uint64_t ramp_time;
 
 /* How long to send constant traffic after the initial ramp-up */
 #define DEFAULT_SUSTAIN_TIME 0
-static isc_uint64_t sustain_time;
+static uint64_t sustain_time;
 
 /* How long to wait for responses after sending traffic */
-static isc_uint64_t wait_time = 40 * MILLION;
+static uint64_t wait_time = 40 * MILLION;
 
 /* Total duration of the traffic-sending part of the test */
-static isc_uint64_t traffic_time;
+static uint64_t traffic_time;
 
 /* Total duration of the test */
-static isc_uint64_t end_time;
+static uint64_t end_time;
 
 /* Interval between plot data points, in microseconds */
 #define DEFAULT_BUCKET_INTERVAL 0.5
-static isc_uint64_t bucket_interval;
+static uint64_t bucket_interval;
 
 /* The number of plot data points */
 static int n_buckets;
@@ -131,15 +130,15 @@ static double max_loss_percent = 100.0;
 /* The maximum number of outstanding queries */
 static unsigned int max_outstanding;
 
-static isc_uint64_t num_queries_sent;
-static isc_uint64_t num_queries_outstanding;
-static isc_uint64_t num_responses_received;
-static isc_uint64_t num_queries_timed_out;
-static isc_uint64_t rcodecounts[16];
+static uint64_t num_queries_sent;
+static uint64_t num_queries_outstanding;
+static uint64_t num_responses_received;
+static uint64_t num_queries_timed_out;
+static uint64_t rcodecounts[16];
 
-static isc_uint64_t time_now;
-static isc_uint64_t time_of_program_start;
-static isc_uint64_t time_of_end_of_run;
+static uint64_t time_now;
+static uint64_t time_of_program_start;
+static uint64_t time_of_end_of_run;
 
 /*
  * The last plot data point containing actual data; this can
@@ -181,7 +180,7 @@ enum phase {
 static enum phase phase = PHASE_RAMP;
 
 /* The time when the sustain/wait phase began */
-static isc_uint64_t sustain_phase_began, wait_phase_began;
+static uint64_t sustain_phase_began, wait_phase_began;
 
 static perf_dnstsigkey_t *tsigkey;
 
@@ -337,8 +336,8 @@ cleanup(void)
 /* Find the ramp_bucket for queries sent at time "when" */
 
 static ramp_bucket *
-find_bucket(isc_uint64_t when) {
-    isc_uint64_t sent_at = when - time_of_program_start;
+find_bucket(uint64_t when) {
+    uint64_t sent_at = when - time_of_program_start;
     int i = (int) ((n_buckets * sent_at) / traffic_time);
     /*
      * Guard against array bounds violations due to roundoff
@@ -361,7 +360,7 @@ print_statistics(void) {
     double max_throughput;
     double loss_at_max_throughput;
     isc_boolean_t first_rcode;
-    isc_uint64_t run_time = time_of_end_of_run - time_of_program_start;
+    uint64_t run_time = time_of_end_of_run - time_of_program_start;
 
     printf("\nStatistics:\n\n");
 
@@ -503,14 +502,14 @@ enter_wait_phase(void) {
 static void
 try_process_response(unsigned int sockindex) {
     unsigned char packet_buffer[MAX_EDNS_PACKET];
-    isc_uint16_t *packet_header;
-    isc_uint16_t qid, rcode;
+    uint16_t *packet_header;
+    uint16_t qid, rcode;
     query_info *q;
     double latency;
     ramp_bucket *b;
     int n;
 
-    packet_header = (isc_uint16_t *) packet_buffer;
+    packet_header = (uint16_t *) packet_buffer;
     n = recvfrom(socks[sockindex], packet_buffer, sizeof(packet_buffer),
                  0, NULL, NULL);
     if (n < 0) {
@@ -569,7 +568,7 @@ retire_old_queries(void)
 }
 
 static inline int
-num_scheduled(isc_uint64_t time_since_start)
+num_scheduled(uint64_t time_since_start)
 {
     if (phase == PHASE_RAMP) {
         return 0.5 * max_qps * (double)time_since_start * time_since_start /
@@ -621,7 +620,7 @@ main(int argc, char **argv) {
     current_sock = 0;
     for (;;) {
         int should_send;
-        isc_uint64_t time_since_start = time_now - time_of_program_start;
+        uint64_t time_since_start = time_now - time_of_program_start;
         switch (phase) {
         case PHASE_RAMP:
             if (time_since_start >= ramp_time)

--- a/util.h
+++ b/util.h
@@ -15,6 +15,7 @@
  */
 
 #include <pthread.h>
+#include <inttypes.h>
 #include <string.h>
 
 #include <sys/time.h>
@@ -26,7 +27,7 @@
 #ifndef PERF_UTIL_H
 #define PERF_UTIL_H 1
 
-#define MILLION ((isc_uint64_t) 1000000)
+#define MILLION ((uint64_t) 1000000)
 
 #define THREAD(thread, start, arg) do {                                     \
     int __n = pthread_create((thread), NULL, (start), (arg));               \
@@ -109,7 +110,7 @@
     }                                                                       \
 } while (0)
 
-static __inline__ isc_uint64_t
+static __inline__ uint64_t
 get_time(void)
 {
     struct timeval tv;

--- a/util.h
+++ b/util.h
@@ -16,6 +16,7 @@
 
 #include <pthread.h>
 #include <inttypes.h>
+#include <stdbool.h>
 #include <string.h>
 
 #include <sys/time.h>
@@ -101,7 +102,7 @@
 
 #define TIMEDWAIT(cond, mutex, when, timedout) do {                         \
     int __n = pthread_cond_timedwait((cond), (mutex), (when));              \
-    isc_boolean_t *res = (timedout);                                        \
+    bool *res = (timedout);                                                 \
     if (__n != 0 && __n != ETIMEDOUT) {                                     \
         perf_log_fatal("pthread_cond_timedwait failed: %s", strerror(__n)); \
     }                                                                       \


### PR DESCRIPTION
Bind 9.13.3 got rid of a number of legacy stuff, including the custom int types and the custom booleans.

As a result, dnsperf also needs to be updated, otherwise it fails to build.

The commits in this PR are simply adapted from the changes in upstream Bind, since dnsperf was still part of their tree (it has been deleted since then):

https://gitlab.isc.org/isc-projects/bind9/commit/64fe6bbaf2019f444475dfbf744eb6ea4e619c19
https://gitlab.isc.org/isc-projects/bind9/commit/cb6a185c692500ccd2c7901edef78729f3c23b72
https://gitlab.isc.org/isc-projects/bind9/commit/994e656977b88516d76519c437b623ddb32b0769
