### PR TITLE
CI, buildbot

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,20 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - build-essential
+        - automake
+        - autoconf
+        - libtool
+        - pkg-config
+        - libbind-dev
+        - libkrb5-dev
+        - libssl-dev
+        - libcap-dev
+        - libxml2-dev
+        - libjson-c-dev
+        - libgeoip-dev
+    configure:
+      command:
+        - ./autogen.sh
+        - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+dist: xenial
+addons:
+  apt:
+    update: true
+    packages:
+    - libbind-dev
+    - libkrb5-dev
+    - libssl-dev
+    - libcap-dev
+    - libxml2-dev
+    - libjson-c-dev
+    - libgeoip-dev
+language: c
+compiler:
+  - clang
+  - gcc
+install: ./autogen.sh
+script:
+  - ./configure --enable-warn-all
+  - make dist
+  - tar zxvf *.tar.gz
+  - cd dnsperf-[0-9]*
+  - mkdir build
+  - cd build
+  - ../configure --enable-warn-all
+  - make
+  - make test

--- a/README.md
+++ b/README.md
@@ -42,6 +42,21 @@ To install the dependencies under Debian/Ubuntu:
 apt-get install -y libbind-dev libkrb5-dev libssl-dev libcap-dev libxml2-dev libjson-c-dev libgeoip-dev
 ```
 
+To install the dependencies under CentOS (with EPEL enabled):
+```
+yum install -y bind-devel krb5-devel openssl-devel libcap-devel libxml2-devel json-c-devel GeoIP-devel
+```
+
+To install the dependencies under FreeBSD 12+ using `pkg`:
+```
+pkg install -y bind913-9.13.5 openssl-devel GeoIP
+```
+
+To install the dependencies under OpenBSD 6+ using `pkg_add`:
+```
+pkg_add isc-bind-9.11.4pl2 GeoIP
+```
+
 ## Building from source tarball
 
 The source tarball from DNS-OARC comes prepared with `configure`:

--- a/configure.ac
+++ b/configure.ac
@@ -50,24 +50,36 @@ AC_CHECK_LIB(socket, socket)
 AC_CHECK_LIB(nsl, inet_ntoa)
 
 # Check for bind
-AC_ARG_WITH(bind,
-[  --with-bind=[[PATH]]      Specify ISC BIND 9 prefix path],
-    use_bind="$withval", use_bind="yes")
+AC_ARG_WITH([bind], [AS_HELP_STRING([--with-bind=PATH], [Specify ISC BIND 9 prefix path])], [
+  use_bind="$withval"
+],[
+  use_bind="yes"
+])
 
-AC_MSG_CHECKING(for BIND 9 libraries)
+AC_MSG_CHECKING([for BIND 9 libraries])
 if test $use_bind = no; then
-    AC_MSG_ERROR(BIND 9 libraries must be installed)
+  AC_MSG_ERROR([BIND 9 libraries must be installed])
 elif test $use_bind = yes; then
-    bindpath="$PATH"
+  bindpath="$PATH"
 else
-    bindpath="$withval/bin"
+  bindpath="$withval/bin"
 fi
-AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], "no", [$bindpath])
+AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], [no], [$bindpath])
 if test "$ac_cv_isc_config" = "no"; then
-  AC_MSG_ERROR(BIND 9 libraries must be installed)
+  AC_MSG_ERROR([BIND 9 libraries must be installed])
 fi
-AC_SUBST(DNSLIBS, "`$ac_cv_isc_config --libs dns bind9`")
-AC_SUBST(DNSCFLAGS, "`$ac_cv_isc_config --cflags dns bind9`")
+
+case "$host_os" in
+  freebsd*)
+    AC_MSG_NOTICE([Add workaround for FreeBSD by using static libcrypto])
+    AS_VAR_APPEND(LDFLAGS, [" /usr/lib/libcrypto.a"])
+    ;;
+esac
+
+AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
+AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
+
+AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,8 +22,7 @@ SUBDIRS =
 
 AM_CFLAGS = -I$(srcdir) \
   -I$(top_srcdir) \
-  $(PTHREAD_CFLAGS) \
-  $(DNSCFLAGS)
+  $(PTHREAD_CFLAGS)
 
 EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 
@@ -35,11 +34,11 @@ _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h version.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)
-dnsperf_LDADD = $(PTHREAD_LIBS) $(DNSLIBS)
+dnsperf_LDADD = $(PTHREAD_LIBS)
 
 resperf_SOURCES = $(_libperf_sources) resperf.c
 dist_resperf_SOURCES = $(_libperf_headers)
-resperf_LDADD = $(PTHREAD_LIBS) $(DNSLIBS)
+resperf_LDADD = $(PTHREAD_LIBS)
 
 man1_MANS = dnsperf.1 resperf.1
 

--- a/src/datafile.c
+++ b/src/datafile.c
@@ -36,6 +36,13 @@
 
 #define BUFFER_SIZE (64 * 1024)
 
+#ifndef ISC_TRUE
+#define ISC_TRUE true
+#endif
+#ifndef ISC_FALSE
+#define ISC_FALSE false
+#endif
+
 struct perf_datafile {
     isc_mem_t *mctx;
     pthread_mutex_t lock;
@@ -67,8 +74,10 @@ perf_datafile_open(isc_mem_t *mctx, const char *filename)
     struct stat buf;
 
     dfile = isc_mem_get(mctx, sizeof(*dfile));
-    if (dfile == NULL)
+    if (dfile == NULL) {
         perf_log_fatal("out of memory");
+        return 0; // fix clang scan-build
+    }
 
     dfile->mctx = mctx;
     MUTEX_INIT(&dfile->lock);

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -60,6 +60,11 @@
 #include "util.h"
 #include "version.h"
 
+#ifndef ISC_UINT64_MAX
+#include <stdint.h>
+#define ISC_UINT64_MAX UINT64_MAX
+#endif
+
 #define DEFAULT_SERVER_NAME             "127.0.0.1"
 #define DEFAULT_SERVER_PORT             53
 #define DEFAULT_LOCAL_PORT              0
@@ -785,7 +790,7 @@ do_recv(void *arg)
     threadinfo_t *tinfo;
     stats_t *stats;
     unsigned char packet_buffer[MAX_EDNS_PACKET];
-    received_query_t recvd[RECV_BATCH_SIZE];
+    received_query_t recvd[RECV_BATCH_SIZE] = { { 0, 0, 0, 0, 0, 0, false, false, 0 } };
     unsigned int nrecvd;
     int saved_errno;
     unsigned char socketbits[MAX_SOCKETS / 8];

--- a/src/opt.c
+++ b/src/opt.c
@@ -82,8 +82,12 @@ perf_opt_add(char c, perf_opttype_t type, const char *desc, const char *help,
     }
     opt->u.valp = valp;
 
-    sprintf(s, "%c%s", c, (type == perf_opt_boolean ? "" : ":"));
+    snprintf(s, sizeof(s), "%c%s", c, (type == perf_opt_boolean ? "" : ":"));
+#ifdef __OpenBSD__
+    strlcat(optstr, s, sizeof(optstr));
+#else
     strcat(optstr, s);
+#endif
 }
 
 void


### PR DESCRIPTION
- Add Travis CI
- Enable building via buildbot
- Add LGTM configuration
- Handle bind library changes to HMAC (see #22) and other differences between versions
- Workaround issue on FreeBSD (see #23)
- Clang `scan-build` fixes
- Use `snprintf()` and OpenBSD's `strlcat()`
- Add build dependencies for CentOS, FreeBSD and OpenBSD