### PR TITLE
remove visible "u" characters after numbers

### DIFF
--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -272,16 +272,16 @@ print_statistics(const config_t* config, const times_t* times, stats_t* stats)
 
     printf("Statistics:\n\n");
 
-    printf("  %s sent:         %" PRIu64 "u\n",
+    printf("  %s sent:         %" PRIu64 "\n",
         units, stats->num_sent);
-    printf("  %s completed:    %" PRIu64 "u (%.2lf%%)\n",
+    printf("  %s completed:    %" PRIu64 " (%.2lf%%)\n",
         units, stats->num_completed,
         SAFE_DIV(100.0 * stats->num_completed, stats->num_sent));
-    printf("  %s lost:         %" PRIu64 "u (%.2lf%%)\n",
+    printf("  %s lost:         %" PRIu64 " (%.2lf%%)\n",
         units, stats->num_timedout,
         SAFE_DIV(100.0 * stats->num_timedout, stats->num_sent));
     if (stats->num_interrupted > 0)
-        printf("  %s interrupted:  %" PRIu64 "u (%.2lf%%)\n",
+        printf("  %s interrupted:  %" PRIu64 " (%.2lf%%)\n",
             units, stats->num_interrupted,
             SAFE_DIV(100.0 * stats->num_interrupted, stats->num_sent));
     printf("\n");
@@ -295,7 +295,7 @@ print_statistics(const config_t* config, const times_t* times, stats_t* stats)
             first_rcode = false;
         else
             printf(", ");
-        printf("%s %" PRIu64 "u (%.2lf%%)",
+        printf("%s %" PRIu64 " (%.2lf%%)",
             perf_dns_rcode_strings[i], stats->rcodecounts[i],
             (stats->rcodecounts[i] * 100.0) / stats->num_completed);
     }

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -372,11 +372,11 @@ print_statistics(void)
 
     printf("\nStatistics:\n\n");
 
-    printf("  Queries sent:         %" PRIu64 "u\n",
+    printf("  Queries sent:         %" PRIu64 "\n",
         num_queries_sent);
-    printf("  Queries completed:    %" PRIu64 "u\n",
+    printf("  Queries completed:    %" PRIu64 "\n",
         num_responses_received);
-    printf("  Queries lost:         %" PRIu64 "u\n",
+    printf("  Queries lost:         %" PRIu64 "\n",
         num_queries_sent - num_responses_received);
     printf("  Response codes:       ");
     first_rcode = true;
@@ -387,7 +387,7 @@ print_statistics(void)
             first_rcode = false;
         else
             printf(", ");
-        printf("%s %" PRIu64 "u (%.2lf%%)",
+        printf("%s %" PRIu64 " (%.2lf%%)",
             perf_dns_rcode_strings[i], rcodecounts[i],
             (rcodecounts[i] * 100.0) / num_responses_received);
     }


### PR DESCRIPTION
It seems an unintetional fallout from c27afd4218b5.