### PR TITLE
Basic TCP support.

### DIFF
--- a/src/dns.h
+++ b/src/dns.h
@@ -24,6 +24,7 @@
 
 #define MAX_UDP_PACKET 512
 #define MAX_EDNS_PACKET 4096
+#define MAX_TCP_PACKET 65535
 
 typedef struct perf_dnstsigkey    perf_dnstsigkey_t;
 typedef struct perf_dnsednsoption perf_dnsednsoption_t;

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -598,6 +598,9 @@ do_send(void* arg)
     times           = tinfo->times;
     stats           = &tinfo->stats;
     max_packet_size = config->edns ? MAX_EDNS_PACKET : MAX_UDP_PACKET;
+    if (config->tcp) {
+        max_packet_size += 2;
+    }
     isc_buffer_init(&msg, packet_buffer, max_packet_size);
     isc_buffer_init(&lines, input_data, sizeof(input_data));
 

--- a/src/net.c
+++ b/src/net.c
@@ -99,7 +99,7 @@ void perf_net_parselocal(int family, const char* name, unsigned int port,
 }
 
 int perf_net_opensocket(const isc_sockaddr_t* server, const isc_sockaddr_t* local,
-    unsigned int offset, int bufsize)
+    int sock_type, unsigned int offset, int bufsize)
 {
     int            family;
     int            sock;
@@ -114,7 +114,7 @@ int perf_net_opensocket(const isc_sockaddr_t* server, const isc_sockaddr_t* loca
         perf_log_fatal("server and local addresses have "
                        "different families");
 
-    sock = socket(family, SOCK_DGRAM, 0);
+    sock = socket(family, sock_type, 0);
     if (sock == -1)
         perf_log_fatal("socket: %s", strerror(errno));
 
@@ -130,7 +130,10 @@ int perf_net_opensocket(const isc_sockaddr_t* server, const isc_sockaddr_t* loca
 
     tmp  = *local;
     port = isc_sockaddr_getport(&tmp);
-    if (port != 0 && offset != 0) {
+    if (sock_type == SOCK_STREAM) {
+        port = 0;
+        isc_sockaddr_setport(&tmp, port);
+    } else if (port != 0 && offset != 0) {
         port += offset;
         if (port >= 0xFFFF)
             perf_log_fatal("port %d out of range", port);

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,6 @@ void perf_net_parselocal(int family, const char* name, unsigned int port,
     isc_sockaddr_t* addr);
 
 int perf_net_opensocket(const isc_sockaddr_t* server, const isc_sockaddr_t* local,
-    unsigned int offset, int bufsize);
+    int sock_type, unsigned int offset, int bufsize);
 
 #endif

--- a/src/os.c
+++ b/src/os.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <signal.h>
 #include <inttypes.h>
+#include <poll.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -102,5 +103,25 @@ perf_os_waituntilanyreadable(int* fds, unsigned int nfds, int pipe_fd,
         return (ISC_R_CANCELED);
     } else {
         return (ISC_R_SUCCESS);
+    }
+}
+
+isc_result_t
+perf_os_iswritable(int fd)
+{
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = POLLOUT;
+
+    int n = poll(&pfd, 1, 0);
+    if (n < 0) {
+        if (errno != EINTR)
+            perf_log_fatal("poll(): %s", strerror(errno));
+        return (ISC_R_CANCELED);
+    }
+    if (n == 1) {
+        return (ISC_R_SUCCESS);
+    } else {
+        return (ISC_R_TIMEDOUT);
     }
 }

--- a/src/os.h
+++ b/src/os.h
@@ -34,4 +34,7 @@ isc_result_t
 perf_os_waituntilanyreadable(int* fds, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 
+isc_result_t
+perf_os_iswritable(int fd);
+
 #endif

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -323,7 +323,8 @@ setup(int argc, char** argv)
     if (socks == NULL)
         perf_log_fatal("out of memory");
     for (i       = 0; i < nsocks; i++)
-        socks[i] = perf_net_opensocket(&server_addr, &local_addr, i, bufsize);
+        socks[i] = perf_net_opensocket(&server_addr, &local_addr, SOCK_DGRAM,
+            i, bufsize);
 }
 
 static void


### PR DESCRIPTION
This adds basic support for sending queries over TCP.

This is not based on https://github.com/Sinodun/dnsperf-tcp, but does reuse the -z option.  It doesn't include any of the other changes there, such as potentially limiting the number of queries over a socket, changing the maximum number of open sockets, or using poll instead of select.

It is, however, far more efficient than the code in that fork, and built on top of the current dnsperf.

Additional functionality can be added later.