### PR TITLE
TCP support

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -146,13 +146,14 @@ reopen_file(perf_datafile_t* dfile)
 static isc_result_t
 read_more(perf_datafile_t* dfile)
 {
-    unsigned char* data;
-    size_t         size;
-    ssize_t        n;
-    isc_result_t   result;
+    unsigned char*         data;
+    size_t                 size;
+    ssize_t                n;
+    isc_result_t           result;
+    struct perf_net_socket sock = {.mode = sock_file, .fd = dfile->fd };
 
     if (!dfile->is_file && dfile->pipe_fd >= 0) {
-        result = perf_os_waituntilreadable(dfile->fd, dfile->pipe_fd, -1);
+        result = perf_os_waituntilreadable(&sock, dfile->pipe_fd, -1);
         if (result != ISC_R_SUCCESS)
             return (result);
     }

--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -30,6 +30,7 @@ dnsperf \- test the performance of a DNS server
 [\fB\-f\ \fIfamily\fB\fR]
 [\fB\-h\fR]
 [\fB\-l\ \fIlimit\fB\fR]
+[\fB\-m\ \fImode\fB\fR]
 [\fB\-n\ \fIruns_through_file\fB\fR]
 [\fB\-p\ \fIport\fB\fR]
 [\fB\-q\ \fInum_queries\fB\fR]
@@ -261,6 +262,12 @@ received or requests time out. The default value is 100.
 .br
 .RS
 Limits the number of requests per second. There is no default limit.
+.RE
+
+\fB-m \fImode\fB\fR
+.br
+.RS
+Specifies the transport mode to use, "udp" or "tcp". Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -101,6 +101,7 @@ typedef struct {
     uint64_t              stats_interval;
     bool                  updates;
     bool                  verbose;
+    enum perf_net_mode    mode;
 } config_t;
 
 typedef struct {
@@ -130,10 +131,10 @@ typedef struct {
 typedef ISC_LIST(struct query_info) query_list;
 
 typedef struct query_info {
-    uint64_t    timestamp;
-    query_list* list;
-    char*       desc;
-    int         sock;
+    uint64_t                timestamp;
+    query_list*             list;
+    char*                   desc;
+    struct perf_net_socket* sock;
     /*
      * This link links the query into the list of outstanding
      * queries or the list of available query IDs.
@@ -155,9 +156,9 @@ typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t  cond;
 
-    unsigned int nsocks;
-    int          current_sock;
-    int*         socks;
+    unsigned int            nsocks;
+    int                     current_sock;
+    struct perf_net_socket* socks;
 
     perf_dnsctx_t* dnsctx;
 
@@ -382,6 +383,7 @@ setup(int argc, char** argv, config_t* config)
     const char*  edns_option = NULL;
     const char*  tsigkey     = NULL;
     isc_result_t result;
+    const char*  mode = 0;
 
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
@@ -399,10 +401,12 @@ setup(int argc, char** argv, config_t* config)
     config->threads         = 1;
     config->timeout         = DEFAULT_TIMEOUT * MILLION;
     config->max_outstanding = DEFAULT_MAX_OUTSTANDING;
+    config->mode            = sock_udp;
 
     perf_opt_add('f', perf_opt_string, "family",
         "address family of DNS transport, inet or inet6", "any",
         &family);
+    perf_opt_add('m', perf_opt_string, "mode", "set transport mode: udp or tcp", "udp", &mode);
     perf_opt_add('s', perf_opt_string, "server_addr",
         "the server to query", DEFAULT_SERVER_NAME, &server_name);
     perf_opt_add('p', perf_opt_port, "port",
@@ -484,6 +488,9 @@ setup(int argc, char** argv, config_t* config)
 
     if (edns_option != NULL)
         config->edns_option = perf_dns_parseednsoption(edns_option, mctx);
+
+    if (mode != 0)
+        config->mode = perf_net_parsemode(mode);
 
     /*
      * If we run more threads than max-qps, some threads will have
@@ -623,7 +630,23 @@ do_send(void* arg)
         q = ISC_LIST_HEAD(tinfo->unused_queries);
         query_move(tinfo, q, prepend_outstanding);
         q->timestamp = ISC_UINT64_MAX;
-        q->sock      = tinfo->socks[tinfo->current_sock++ % tinfo->nsocks];
+        while (1) {
+            q->sock = &tinfo->socks[tinfo->current_sock++ % tinfo->nsocks];
+            switch (perf_net_sockready(q->sock, threadpipe[0], TIMEOUT_CHECK_TIME)) {
+            case 0:
+                if (config->verbose) {
+                    perf_log_warning("socket %p not ready", q->sock);
+                }
+                continue;
+            case -1:
+                if (config->verbose) {
+                    perf_log_warning("socket %p readiness check timed out", q->sock);
+                }
+            default:
+                break;
+            }
+            break;
+        };
 
         UNLOCK(&tinfo->lock);
 
@@ -664,10 +687,10 @@ do_send(void* arg)
 
         stats->num_sent++;
 
-        n = sendto(q->sock, base, length, 0, &config->server_addr.type.sa,
+        n = perf_net_sendto(q->sock, base, length, 0, &config->server_addr.type.sa,
             config->server_addr.length);
         if (n < 0 || (unsigned int)n != length) {
-            perf_log_warning("failed to send packet: %s",
+            perf_log_warning("failed to send packet[%d]: %s", n,
                 strerror(errno));
             LOCK(&tinfo->lock);
             query_move(tinfo, q, prepend_unused);
@@ -719,15 +742,15 @@ process_timeouts(threadinfo_t* tinfo, uint64_t now)
 }
 
 typedef struct {
-    int          sock;
-    uint16_t     qid;
-    uint16_t     rcode;
-    unsigned int size;
-    uint64_t     when;
-    uint64_t     sent;
-    bool         unexpected;
-    bool         short_response;
-    char*        desc;
+    struct perf_net_socket* sock;
+    uint16_t                qid;
+    uint16_t                rcode;
+    unsigned int            size;
+    uint64_t                when;
+    uint64_t                sent;
+    bool                    unexpected;
+    bool                    short_response;
+    char*                   desc;
 } received_query_t;
 
 static bool
@@ -736,20 +759,18 @@ recv_one(threadinfo_t* tinfo, int which_sock,
     received_query_t* recvd, int* saved_errnop)
 {
     uint16_t* packet_header;
-    int       s;
     uint64_t  now;
     int       n;
 
     packet_header = (uint16_t*)packet_buffer;
 
-    s   = tinfo->socks[which_sock];
-    n   = recv(s, packet_buffer, packet_size, 0);
+    n   = perf_net_recv(&tinfo->socks[which_sock], packet_buffer, packet_size, 0);
     now = get_time();
     if (n < 0) {
         *saved_errnop = errno;
         return false;
     }
-    recvd->sock           = s;
+    recvd->sock           = &tinfo->socks[which_sock];
     recvd->qid            = ntohs(packet_header[0]);
     recvd->rcode          = ntohs(packet_header[1]) & 0xF;
     recvd->size           = n;
@@ -847,7 +868,7 @@ do_recv(void* arg)
                 continue;
 
             q = &tinfo->queries[recvd[i].qid];
-            if (q->list != &tinfo->outstanding_queries || q->timestamp == ISC_UINT64_MAX || q->sock != recvd[i].sock) {
+            if (q->list != &tinfo->outstanding_queries || q->timestamp == ISC_UINT64_MAX || !perf_net_sockeq(q->sock, recvd[i].sock)) {
                 recvd[i].unexpected = true;
                 continue;
             }
@@ -922,21 +943,22 @@ do_recv(void* arg)
 static void*
 do_interval_stats(void* arg)
 {
-    threadinfo_t* tinfo;
-    stats_t       total;
-    uint64_t      now;
-    uint64_t      last_interval_time;
-    uint64_t      last_completed;
-    uint64_t      interval_time;
-    uint64_t      num_completed;
-    double        qps;
+    threadinfo_t*          tinfo;
+    stats_t                total;
+    uint64_t               now;
+    uint64_t               last_interval_time;
+    uint64_t               last_completed;
+    uint64_t               interval_time;
+    uint64_t               num_completed;
+    double                 qps;
+    struct perf_net_socket sock = {.mode = sock_pipe, .fd = threadpipe[0] };
 
     tinfo              = arg;
     last_interval_time = tinfo->times->start_time;
     last_completed     = 0;
 
     wait_for_start();
-    while (perf_os_waituntilreadable(threadpipe[0], threadpipe[0],
+    while (perf_os_waituntilreadable(&sock, threadpipe[0],
                tinfo->config->stats_interval)
            == ISC_R_TIMEDOUT) {
         now = get_time();
@@ -1036,14 +1058,14 @@ threadinfo_init(threadinfo_t* tinfo, const config_t* config,
     if (tinfo->nsocks > MAX_SOCKETS)
         tinfo->nsocks = MAX_SOCKETS;
 
-    tinfo->socks = isc_mem_get(mctx, tinfo->nsocks * sizeof(int));
+    tinfo->socks = isc_mem_get(mctx, tinfo->nsocks * sizeof(*tinfo->socks));
     if (tinfo->socks == NULL)
         perf_log_fatal("out of memory");
     socket_offset = 0;
     for (i = 0; i < offset; i++)
         socket_offset += threads[i].nsocks;
     for (i              = 0; i < tinfo->nsocks; i++)
-        tinfo->socks[i] = perf_net_opensocket(&config->server_addr,
+        tinfo->socks[i] = perf_net_opensocket(config->mode, &config->server_addr,
             &config->local_addr,
             socket_offset++,
             config->bufsize);
@@ -1069,8 +1091,8 @@ threadinfo_cleanup(threadinfo_t* tinfo, times_t* times)
     if (interrupted)
         cancel_queries(tinfo);
     for (i = 0; i < tinfo->nsocks; i++)
-        close(tinfo->socks[i]);
-    isc_mem_put(mctx, tinfo->socks, tinfo->nsocks * sizeof(int));
+        perf_net_close(&tinfo->socks[i]);
+    isc_mem_put(mctx, tinfo->socks, tinfo->nsocks * sizeof(*tinfo->socks));
     perf_dns_destroyctx(&tinfo->dnsctx);
     if (tinfo->last_recv > times->end_time)
         times->end_time = tinfo->last_recv;
@@ -1078,12 +1100,13 @@ threadinfo_cleanup(threadinfo_t* tinfo, times_t* times)
 
 int main(int argc, char** argv)
 {
-    config_t     config;
-    times_t      times;
-    stats_t      total_stats;
-    threadinfo_t stats_thread;
-    unsigned int i;
-    isc_result_t result;
+    config_t               config;
+    times_t                times;
+    stats_t                total_stats;
+    threadinfo_t           stats_thread;
+    unsigned int           i;
+    isc_result_t           result;
+    struct perf_net_socket sock = {.mode = sock_pipe };
 
     printf("DNS Performance Testing Tool\n"
            "Version " PACKAGE_VERSION "\n\n");
@@ -1125,7 +1148,8 @@ int main(int argc, char** argv)
 
     perf_os_handlesignal(SIGINT, handle_sigint);
     perf_os_blocksignal(SIGINT, false);
-    result = perf_os_waituntilreadable(mainpipe[0], intrpipe[0],
+    sock.fd = mainpipe[0];
+    result  = perf_os_waituntilreadable(&sock, intrpipe[0],
         times.stop_time - times.start_time);
     if (result == ISC_R_CANCELED)
         interrupted = true;

--- a/src/net.h
+++ b/src/net.h
@@ -20,6 +20,31 @@
 #ifndef PERF_NET_H
 #define PERF_NET_H 1
 
+#include <sys/types.h>
+#include <sys/socket.h>
+
+enum perf_net_mode {
+    sock_none,
+    sock_file,
+    sock_pipe,
+    sock_udp,
+    sock_tcp
+};
+
+struct perf_net_socket {
+    enum perf_net_mode mode;
+    int                fd, have_more, is_ready;
+    char*              recvbuf;
+    size_t             at;
+    char*              sendbuf;
+};
+
+ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags);
+ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags,
+    const struct sockaddr* dest_addr, socklen_t addrlen);
+int perf_net_close(struct perf_net_socket* sock);
+int perf_net_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b);
+
 int perf_net_parsefamily(const char* family);
 
 void perf_net_parseserver(int family, const char* name, unsigned int port,
@@ -28,7 +53,11 @@ void perf_net_parseserver(int family, const char* name, unsigned int port,
 void perf_net_parselocal(int family, const char* name, unsigned int port,
     isc_sockaddr_t* addr);
 
-int perf_net_opensocket(const isc_sockaddr_t* server, const isc_sockaddr_t* local,
+struct perf_net_socket perf_net_opensocket(enum perf_net_mode mode, const isc_sockaddr_t* server, const isc_sockaddr_t* local,
     unsigned int offset, int bufsize);
+
+enum perf_net_mode perf_net_parsemode(const char* mode);
+
+int perf_net_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
 
 #endif

--- a/src/os.h
+++ b/src/os.h
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "net.h"
+
 #ifndef PERF_OS_H
 #define PERF_OS_H 1
 
@@ -28,10 +30,14 @@ void perf_os_blocksignal(int sig, bool block);
 void perf_os_handlesignal(int sig, void (*handler)(int));
 
 isc_result_t
-perf_os_waituntilreadable(int fd, int pipe_fd, int64_t timeout);
+perf_os_waituntilreadable(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
 
 isc_result_t
-perf_os_waituntilanyreadable(int* fds, unsigned int nfds, int pipe_fd,
+perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
+    int64_t timeout);
+
+isc_result_t
+perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 
 #endif

--- a/src/resperf.1.in
+++ b/src/resperf.1.in
@@ -22,6 +22,7 @@ resperf \- test the resolution performance of a caching DNS server
 .ad l
 \fBresperf\-report\fR\ [\fB\-a\ \fIlocal_addr\fB\fR]
 [\fB\-d\ \fIdatafile\fB\fR]
+[\fB\-M\ \fImode\fB\fR]
 [\fB\-s\ \fIserver_addr\fB\fR]
 [\fB\-p\ \fIport\fB\fR]
 [\fB\-x\ \fIlocal_port\fB\fR]
@@ -46,6 +47,7 @@ resperf \- test the resolution performance of a caching DNS server
 
 \fBresperf\fR\ [\fB\-a\ \fIlocal_addr\fB\fR]
 [\fB\-d\ \fIdatafile\fB\fR]
+[\fB\-M\ \fImode\fB\fR]
 [\fB\-s\ \fIserver_addr\fB\fR]
 [\fB\-p\ \fIport\fB\fR]
 [\fB\-x\ \fIlocal_port\fB\fR]
@@ -384,6 +386,12 @@ not itself take a \fB\-P\fR option.
 .RS
 Specifies the input data file. If not specified, \fBresperf\fR will read
 from standard input.
+.RE
+
+\fB-M \fImode\fB\fR
+.br
+.RS
+Specifies the transport mode to use, "udp" or "tcp". Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR


### PR DESCRIPTION
- Add TCP support
  - Rework sock structure to include a mode
  - Add mode for file, pipe, UDP and TCP
  - Add `perf_net_*` functions to handle sock things, such as sending and receiving
  - Use sock structure in `perf_os_*` functions
  - Add `perf_os_waituntilanywritable()`
- `dnsperf`: Add `-m` for setting transport mode, UDP or TCP
- `resperf`: Add `-M` for setting transport mode, UDP or TCP