### PR TITLE
TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ those queries to DNS servers to measure performance.
 ## Dependencies
 
 `dnsperf` requires a couple of libraries beside a normal C compiling
-environment with autoconf, automake, libtool.
+environment with autoconf, automake, libtool and pkgconfig.
 
 `dnsperf` has a non-optional dependency on the BIND library and development
 files along with all dependencies it requires.
@@ -45,7 +45,7 @@ apt-get install -y libbind-dev libkrb5-dev libssl-dev libcap-dev libxml2-dev lib
 Depending on how BIND is compiled on Debian and Ubuntu you might need these
 dependencies also:
 ```
-apt-get install -y libprotobuf-c-dev libfstrm-dev liblmdb-dev
+apt-get install -y libprotobuf-c-dev libfstrm-dev liblmdb-dev libssl-dev
 ```
 
 To install the dependencies under CentOS (with EPEL enabled):

--- a/configure.ac
+++ b/configure.ac
@@ -81,6 +81,13 @@ AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
 
 AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
+# Check for OpenSSL
+PKG_CHECK_MODULES([libssl], [libssl])
+AC_CHECK_LIB([ssl], [SSL_has_pending],
+	[AC_DEFINE([HAVE_SSL_HAS_PENDING], [1], [Define to 1 if you have the `SSL_has_pending' function])])
+AC_CHECK_LIB([ssl], [TLS_client_method],
+	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the `TLS_client_method' function])])
+
 # Checks for sizes
 AX_TYPE_SOCKLEN_T
 AX_SA_LEN

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
  libtool, libbind-dev, libkrb5-dev, libssl-dev, libcap-dev, libxml2-dev,
- libjson-c-dev, libgeoip-dev, libprotobuf-c-dev, libfstrm-dev, liblmdb-dev
+ libjson-c-dev, libgeoip-dev, libprotobuf-c-dev, libfstrm-dev, liblmdb-dev,
+ pkg-config
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/dnsperf
 Vcs-Git: https://github.com/DNS-OARC/dnsperf.git

--- a/rpm/dnsperf.spec
+++ b/rpm/dnsperf.spec
@@ -24,6 +24,7 @@ BuildRequires:  libjson-c-devel
 BuildRequires:  json-c-devel
 %endif
 BuildRequires:  GeoIP-devel
+BuildRequires:  pkgconfig
 
 %description
 dnsperf and resperf are free tools developed by Nominum/Akamai (2006-2018)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ SUBDIRS =
 
 AM_CFLAGS = -I$(srcdir) \
   -I$(top_srcdir) \
-  $(PTHREAD_CFLAGS)
+  $(PTHREAD_CFLAGS) $(libssl_CFLAGS)
 
 EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 
@@ -34,11 +34,11 @@ _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)
-dnsperf_LDADD = $(PTHREAD_LIBS)
+dnsperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
 
 resperf_SOURCES = $(_libperf_sources) resperf.c
 dist_resperf_SOURCES = $(_libperf_headers)
-resperf_LDADD = $(PTHREAD_LIBS)
+resperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
 
 man1_MANS = dnsperf.1 resperf.1
 

--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -247,7 +247,7 @@ the file may be read fewer times.
 .br
 .RS
 Sets the port on which the DNS packets are sent. If not specified, the
-standard DNS port (53) is used.
+standard DNS port (udp/tcp 53, tls 853) is used.
 .RE
 
 \fB-q \fInum_queries\fB\fR
@@ -267,7 +267,7 @@ Limits the number of requests per second. There is no default limit.
 \fB-m \fImode\fB\fR
 .br
 .RS
-Specifies the transport mode to use, "udp" or "tcp". Default is "udp".
+Specifies the transport mode to use, "udp", "tcp" or "tls". Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR
@@ -315,7 +315,8 @@ Enables verbose mode. The DNS RCODE of each response will be reported to
 standard output when the response is received, as will the latency. If a
 query times out, it will be reported with the special string "T" instead of
 a normal DNS RCODE. If a query is interrupted, it will be reported with the
-special string "I".
+special string "I". Additional information regarding network readiness and
+congestion will also be reported.
 .RE
 
 \fB-x \fIlocal_port\fB\fR

--- a/src/net.h
+++ b/src/net.h
@@ -22,23 +22,28 @@
 
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <openssl/ssl.h>
+#include <pthread.h>
 
 enum perf_net_mode {
     sock_none,
     sock_file,
     sock_pipe,
     sock_udp,
-    sock_tcp
+    sock_tcp,
+    sock_tls
 };
 
 struct perf_net_socket {
     enum perf_net_mode      mode;
-    int                     fd, have_more, is_ready, flags;
+    int                     fd, have_more, is_ready, flags, is_ssl_ready;
     char*                   recvbuf;
     size_t                  at, sending;
     char*                   sendbuf;
     struct sockaddr_storage dest_addr;
     socklen_t               addrlen;
+    SSL*                    ssl;
+    pthread_mutex_t         lock;
 };
 
 ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags);

--- a/src/resperf.1.in
+++ b/src/resperf.1.in
@@ -40,6 +40,7 @@ resperf \- test the resolution performance of a caching DNS server
 [\fB\-L\ \fImax_loss\fB\fR]
 [\fB\-C\ \fIclients\fB\fR]
 [\fB\-q\ \fImax_outstanding\fB\fR]
+[\fB\-v\fR]
 .ad
 .hy
 .hy 0
@@ -66,6 +67,7 @@ resperf \- test the resolution performance of a caching DNS server
 [\fB\-L\ \fImax_loss\fB\fR]
 [\fB\-C\ \fIclients\fB\fR]
 [\fB\-q\ \fImax_outstanding\fB\fR]
+[\fB\-v\fR]
 .ad
 .hy
 .SH DESCRIPTION
@@ -391,7 +393,7 @@ from standard input.
 \fB-M \fImode\fB\fR
 .br
 .RS
-Specifies the transport mode to use, "udp" or "tcp". Default is "udp".
+Specifies the transport mode to use, "udp", "tcp" or "tls". Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR
@@ -405,7 +407,7 @@ The default is the loopback address, 127.0.0.1.
 .br
 .RS
 Sets the port on which the DNS packets are sent. If not specified, the
-standard DNS port (53) is used.
+standard DNS port (udp/tcp 53, tls 853) is used.
 .RE
 
 \fB-a \fIlocal_addr\fB\fR
@@ -555,6 +557,12 @@ default is to act as 1 client.
 Sets the maximum number of outstanding requests. \fBresperf\fR will stop
 ramping up traffic when this many queries are outstanding. The default is
 64k, and the limit is 64k per client.
+.RE
+
+\fB-v\fR
+.br
+.RS
+Enables verbose mode to report about network readiness and congestion.
 .RE
 .SH "THE PLOT DATA FILE"
 The plot data file is written by the \fBresperf\fR program and contains the


### PR DESCRIPTION
- Add transport mode `tls`
  - Default server port selected by mode, udp/tcp port 53 and tls port 853
- `dnsperf`: Only show network congested warnings if verbose is used
- `resperf`: Add `-v` for verbose messages, only show network message if verbose