### PR TITLE
TCP/TLS receive

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,8 +83,6 @@ AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
 # Check for OpenSSL
 PKG_CHECK_MODULES([libssl], [libssl])
-AC_CHECK_LIB([ssl], [SSL_has_pending],
-	[AC_DEFINE([HAVE_SSL_HAS_PENDING], [1], [Define to 1 if you have the `SSL_has_pending' function])])
 AC_CHECK_LIB([ssl], [TLS_client_method],
 	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the `TLS_client_method' function])])
 

--- a/src/net.c
+++ b/src/net.c
@@ -235,8 +235,6 @@ ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int f
         uint16_t dnslen, dnslen2;
 
         if (!sock->have_more) {
-            struct pollfd p = { sock->fd, POLLIN, 0 };
-
             if (pthread_mutex_lock(&sock->lock)) {
                 perf_log_fatal("pthread_mutex_lock() failed");
             }
@@ -246,16 +244,6 @@ ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int f
                 }
                 errno = EAGAIN;
                 return -1;
-            }
-#ifdef HAVE_SSL_HAS_PENDING
-            if (!SSL_has_pending(sock->ssl)) {
-#else
-            if (!SSL_pending(sock->ssl)) {
-#endif
-                if (poll(&p, 1, 10) == 1 && !(p.revents & POLLIN)) {
-                    errno = EAGAIN;
-                    return -1;
-                }
             }
 
             n = SSL_read(sock->ssl, sock->recvbuf + sock->at, TCP_RECV_BUF_SIZE - sock->at);
@@ -309,13 +297,6 @@ ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int f
         uint16_t dnslen, dnslen2;
 
         if (!sock->have_more) {
-            // Poll TCP sock to not choke it with recv(), increased throughput by ~50%
-            struct pollfd p = { sock->fd, POLLIN, 0 };
-            if (poll(&p, 1, 10) == 1 && !(p.revents & POLLIN)) {
-                errno = EAGAIN;
-                return -1;
-            }
-
             n = recv(sock->fd, sock->recvbuf + sock->at, TCP_RECV_BUF_SIZE - sock->at, flags);
             if (n < 0) {
                 return n;


### PR DESCRIPTION
- `perf_net_recv()`:
  - Fix #43: Remove `poll()` for TCP
  - Remove `SSL_has_pending()`/`poll()` for TLS