### PR TITLE
COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -12,7 +12,6 @@ $(top)/rpmbuild:
 	mkdir -p $(top)/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 srpm: prereq $(top)/dist-tools $(top)/rpmbuild
-	git checkout -b autobuild
 	nosign=yes $(top)/dist-tools/create-source-packages rpm
 	cp ../*.orig.tar.gz $(top)/rpmbuild/SOURCES/
 	rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist "$(spec)"


### PR DESCRIPTION
- `.copr`: Remove `autobuild` branch checkout