### PR TITLE
COPR

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -15,6 +15,7 @@ $(top)/rpmbuild:
 	mkdir -p "$(top)"/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 srpm: prereq update-dist-tools
+	test -f .gitmodules && git submodule update --init || true
 	overwrite=yes nosign=yes "$(top)/dist-tools/create-source-packages" rpm
 	cp ../*.orig.tar.gz "$(top)/rpmbuild/SOURCES/"
 	rpmbuild -bs --define "%_topdir $(top)/rpmbuild" --undefine=dist "$(spec)"


### PR DESCRIPTION
- `.copr`: Add support for submodules if present