### PR TITLE
Bind 9.16

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,12 @@ if test "$ac_cv_isc_config" = "no"; then
     AC_MSG_ERROR([Install BIND9 development files]))
   AC_CHECK_LIB([dns], [dns_name_init], [],
     AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_LIB([bind9], [bind9_getaddresses], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_HEADER([isc/result.h], [],
+    AC_MSG_ERROR([Install BIND9 header files]))
+  AC_CHECK_HEADER([bind9/getaddresses.h], [],
+    AC_MSG_ERROR([Install BIND9 header files]))
 else
   AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
   AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])

--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,35 @@ else
 fi
 AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], [no], [$bindpath])
 if test "$ac_cv_isc_config" = "no"; then
-  AC_MSG_ERROR([BIND 9 libraries must be installed])
+  AC_CHECK_LIB([isc], [isc_mem_create], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_LIB([dns], [dns_name_init], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+else
+  AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
+  AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
 fi
+
+AC_MSG_CHECKING([return type of isc_mem_create])
+returns=undefined
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/mem.h>]],
+      [[ isc_result_t result = isc_mem_create(0, 0, NULL) ]])],
+  [returns=isc_result_t
+   AC_DEFINE([HAVE_ISC_MEM_CREATE_RESULT], [1], [Define to 1 if 'isc_mem_create' returns result])],
+  [returns=void]
+)
+AC_MSG_RESULT([$returns])
+
+AC_MSG_CHECKING([return type of isc_buffer_allocate])
+returns=undefined
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/buffer.h>]],
+      [[ isc_result_t result = isc_buffer_allocate(NULL, NULL, 0) ]])],
+  [returns=isc_result_t
+   AC_DEFINE([HAVE_ISC_BUFFER_ALLOCATE_RESULT], [1], [Define to 1 if 'isc_buffer_allocate' returns result])],
+  [returns=void]
+)
+AC_MSG_RESULT([$returns])
+
 
 case "$host_os" in
   freebsd*)
@@ -77,15 +104,12 @@ case "$host_os" in
     ;;
 esac
 
-AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
-AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
-
 AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
 # Check for OpenSSL
 PKG_CHECK_MODULES([libssl], [libssl])
 AC_CHECK_LIB([ssl], [TLS_client_method],
-	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the `TLS_client_method' function])])
+	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,9 @@ AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 PKG_CHECK_MODULES([libssl], [libssl])
 AC_CHECK_LIB([ssl], [TLS_client_method],
 	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
+PKG_CHECK_MODULES([libcrypto], [libcrypto])
+AC_CHECK_LIB([crypto], [ERR_get_error],
+	[AC_DEFINE([HAVE_ERR_GET_ERROR], [1], [Define to 1 if you have the 'ERR_get_error' function])])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ SUBDIRS =
 
 AM_CFLAGS = -I$(srcdir) \
   -I$(top_srcdir) \
-  $(PTHREAD_CFLAGS) $(libssl_CFLAGS)
+  $(PTHREAD_CFLAGS) $(libssl_CFLAGS) $(libcrypto_CFLAGS)
 
 EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 
@@ -34,11 +34,11 @@ _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)
-dnsperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
+dnsperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS) $(libcrypto_LIBS)
 
 resperf_SOURCES = $(_libperf_sources) resperf.c
 dist_resperf_SOURCES = $(_libperf_headers)
-resperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
+resperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS) $(libcrypto_LIBS)
 
 man1_MANS = dnsperf.1 resperf.1
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -137,10 +137,14 @@ perf_dns_createctx(bool updates)
         return NULL;
 
     mctx   = NULL;
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     ctx = isc_mem_get(mctx, sizeof(*ctx));
     if (ctx == NULL) {
@@ -373,9 +377,13 @@ perf_dns_parseednsoption(const char* arg, isc_mem_t* mctx)
 
     option->mctx   = mctx;
     option->buffer = NULL;
+#ifdef HAVE_ISC_BUFFER_ALLOCATE_RESULT
     result         = isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("out of memory");
+#else
+    isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
+#endif
 
     result = isc_parse_uint16(&code, copy, 0);
     if (result != ISC_R_SUCCESS) {

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -389,10 +389,14 @@ setup(int argc, char** argv, config_t* config)
     isc_result_t result;
     const char*  mode = 0;
 
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     dns_result_register();
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -228,10 +228,14 @@ setup(int argc, char** argv)
     isc_result_t result;
     const char*  _mode = 0;
 
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     dns_result_register();
 


### PR DESCRIPTION
My version of issue #67 fix. Uses autoconf check when isc-config.sh is missing.

Builds succesfully on Fedora 30,
openssl-libs-1.1.1d-2.fc30.x86_64
bind-devel-9.16.2-4.fc30.x86_64

But I have to use ./configure CPPFLAGS=-I/usr/include/bind9 to configure it