### PR TITLE
BIND, libcrypto, clang format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,12 @@ if test "$ac_cv_isc_config" = "no"; then
     AC_MSG_ERROR([Install BIND9 development files]))
   AC_CHECK_LIB([dns], [dns_name_init], [],
     AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_LIB([bind9], [bind9_getaddresses], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_HEADER([isc/result.h], [],
+    AC_MSG_ERROR([Install BIND9 header files]))
+  AC_CHECK_HEADER([bind9/getaddresses.h], [],
+    AC_MSG_ERROR([Install BIND9 header files]))
 else
   AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
   AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])

--- a/configure.ac
+++ b/configure.ac
@@ -67,8 +67,35 @@ else
 fi
 AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], [no], [$bindpath])
 if test "$ac_cv_isc_config" = "no"; then
-  AC_MSG_ERROR([BIND 9 libraries must be installed])
+  AC_CHECK_LIB([isc], [isc_mem_create], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+  AC_CHECK_LIB([dns], [dns_name_init], [],
+    AC_MSG_ERROR([Install BIND9 development files]))
+else
+  AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
+  AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
 fi
+
+AC_MSG_CHECKING([return type of isc_mem_create])
+returns=undefined
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/mem.h>]],
+      [[ isc_result_t result = isc_mem_create(0, 0, NULL) ]])],
+  [returns=isc_result_t
+   AC_DEFINE([HAVE_ISC_MEM_CREATE_RESULT], [1], [Define to 1 if 'isc_mem_create' returns result])],
+  [returns=void]
+)
+AC_MSG_RESULT([$returns])
+
+AC_MSG_CHECKING([return type of isc_buffer_allocate])
+returns=undefined
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/buffer.h>]],
+      [[ isc_result_t result = isc_buffer_allocate(NULL, NULL, 0) ]])],
+  [returns=isc_result_t
+   AC_DEFINE([HAVE_ISC_BUFFER_ALLOCATE_RESULT], [1], [Define to 1 if 'isc_buffer_allocate' returns result])],
+  [returns=void]
+)
+AC_MSG_RESULT([$returns])
+
 
 case "$host_os" in
   freebsd*)
@@ -77,15 +104,12 @@ case "$host_os" in
     ;;
 esac
 
-AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
-AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
-
 AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
 # Check for OpenSSL
 PKG_CHECK_MODULES([libssl], [libssl])
 AC_CHECK_LIB([ssl], [TLS_client_method],
-	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the `TLS_client_method' function])])
+	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,7 @@ else
 fi
 AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], [no], [$bindpath])
 if test "$ac_cv_isc_config" = "no"; then
+# BIND 9.16+
   AC_CHECK_LIB([isc], [isc_mem_create], [],
     AC_MSG_ERROR([Install BIND9 development files]))
   AC_CHECK_LIB([dns], [dns_name_init], [],
@@ -78,6 +79,7 @@ if test "$ac_cv_isc_config" = "no"; then
   AC_CHECK_HEADER([bind9/getaddresses.h], [],
     AC_MSG_ERROR([Install BIND9 header files]))
 else
+# BIND <= 9.14
   AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
   AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
 fi
@@ -102,23 +104,13 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/buffer.h>]],
 )
 AC_MSG_RESULT([$returns])
 
-
-case "$host_os" in
-  freebsd*)
-    AC_MSG_NOTICE([Add workaround for FreeBSD by using static libcrypto])
-    AS_VAR_APPEND(LDFLAGS, [" /usr/lib/libcrypto.a"])
-    ;;
-esac
-
 AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 
 # Check for OpenSSL
 PKG_CHECK_MODULES([libssl], [libssl])
+PKG_CHECK_MODULES([libcrypto], [libcrypto]) # also check libcrypto which might be needed for libssl
 AC_CHECK_LIB([ssl], [TLS_client_method],
 	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
-PKG_CHECK_MODULES([libcrypto], [libcrypto])
-AC_CHECK_LIB([crypto], [ERR_get_error],
-	[AC_DEFINE([HAVE_ERR_GET_ERROR], [1], [Define to 1 if you have the 'ERR_get_error' function])])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/configure.ac
+++ b/configure.ac
@@ -116,6 +116,9 @@ AC_CHECK_HEADERS([isc/hmacmd5.h isc/hmacsha.h])
 PKG_CHECK_MODULES([libssl], [libssl])
 AC_CHECK_LIB([ssl], [TLS_client_method],
 	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
+PKG_CHECK_MODULES([libcrypto], [libcrypto])
+AC_CHECK_LIB([crypto], [ERR_get_error],
+	[AC_DEFINE([HAVE_ERR_GET_ERROR], [1], [Define to 1 if you have the 'ERR_get_error' function])])
 
 # Checks for sizes
 AX_TYPE_SOCKLEN_T

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-clang-format-4.0 \
+clang-format \
     -style=file \
     -i \
     src/*.c \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -22,7 +22,7 @@ SUBDIRS =
 
 AM_CFLAGS = -I$(srcdir) \
   -I$(top_srcdir) \
-  $(PTHREAD_CFLAGS) $(libssl_CFLAGS)
+  $(PTHREAD_CFLAGS) $(libssl_CFLAGS) $(libcrypto_CFLAGS)
 
 EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 
@@ -34,11 +34,11 @@ _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)
-dnsperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
+dnsperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS) $(libcrypto_LIBS)
 
 resperf_SOURCES = $(_libperf_sources) resperf.c
 dist_resperf_SOURCES = $(_libperf_headers)
-resperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS)
+resperf_LDADD = $(PTHREAD_LIBS) $(libssl_LIBS) $(libcrypto_LIBS)
 
 man1_MANS = dnsperf.1 resperf.1
 

--- a/src/datafile.c
+++ b/src/datafile.c
@@ -150,7 +150,7 @@ read_more(perf_datafile_t* dfile)
     size_t                 size;
     ssize_t                n;
     isc_result_t           result;
-    struct perf_net_socket sock = {.mode = sock_file, .fd = dfile->fd };
+    struct perf_net_socket sock = { .mode = sock_file, .fd = dfile->fd };
 
     if (!dfile->is_file && dfile->pipe_fd >= 0) {
         result = perf_os_waituntilreadable(&sock, dfile->pipe_fd, -1);

--- a/src/dns.c
+++ b/src/dns.c
@@ -137,10 +137,14 @@ perf_dns_createctx(bool updates)
         return NULL;
 
     mctx   = NULL;
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     ctx = isc_mem_get(mctx, sizeof(*ctx));
     if (ctx == NULL) {
@@ -373,9 +377,13 @@ perf_dns_parseednsoption(const char* arg, isc_mem_t* mctx)
 
     option->mctx   = mctx;
     option->buffer = NULL;
+#ifdef HAVE_ISC_BUFFER_ALLOCATE_RESULT
     result         = isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("out of memory");
+#else
+    isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
+#endif
 
     result = isc_parse_uint16(&code, copy, 0);
     if (result != ISC_R_SUCCESS) {

--- a/src/dns.c
+++ b/src/dns.c
@@ -136,7 +136,7 @@ perf_dns_createctx(bool updates)
     if (!updates)
         return NULL;
 
-    mctx   = NULL;
+    mctx = NULL;
 #ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
@@ -301,7 +301,7 @@ perf_dns_parsetsigkey(const char* arg, isc_mem_t* mctx)
         perf_log_fatal("unable to setup TSIG algorithm %.*s, digest buffer too small, please report to %s", alglen, alg, PACKAGE_BUGREPORT);
     }
 
-/* Name */
+    /* Name */
 
 #ifdef dns_fixedname_init
     dns_fixedname_init(&tsigkey->fname);
@@ -378,7 +378,7 @@ perf_dns_parseednsoption(const char* arg, isc_mem_t* mctx)
     option->mctx   = mctx;
     option->buffer = NULL;
 #ifdef HAVE_ISC_BUFFER_ALLOCATE_RESULT
-    result         = isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
+    result = isc_buffer_allocate(mctx, &option->buffer, strlen(value) / 2 + 4);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("out of memory");
 #else
@@ -917,7 +917,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
         if (token_equals(&token, "send")) {
             break;
         } else if (token_equals(&token, "add")) {
-            result = read_update_line(ctx, &input, str, zname,
+            result    = read_update_line(ctx, &input, str, zname,
                 true, true, true,
                 true, oname, &ttl, &rdtype,
                 &rdata, &rdatabuf);
@@ -932,7 +932,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
                 rdclass = dns_rdataclass_none;
             else
                 rdclass = dns_rdataclass_any;
-            is_update   = true;
+            is_update = true;
         } else if (token_equals(&token, "require")) {
             result = read_update_line(ctx, &input, str, zname,
                 false, false, true,
@@ -942,9 +942,9 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
                 rdclass = dns_rdataclass_in;
             else
                 rdclass = dns_rdataclass_any;
-            is_update   = false;
+            is_update = false;
         } else if (token_equals(&token, "prohibit")) {
-            result = read_update_line(ctx, &input, str, zname,
+            result    = read_update_line(ctx, &input, str, zname,
                 false, false, false,
                 false, oname, &ttl,
                 &rdtype, &rdata, &rdatabuf);

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -1004,7 +1004,7 @@ do_interval_stats(void* arg)
     uint64_t               interval_time;
     uint64_t               num_completed;
     double                 qps;
-    struct perf_net_socket sock = {.mode = sock_pipe, .fd = threadpipe[0] };
+    struct perf_net_socket sock = { .mode = sock_pipe, .fd = threadpipe[0] };
 
     tinfo              = arg;
     last_interval_time = tinfo->times->start_time;
@@ -1099,8 +1099,8 @@ threadinfo_init(threadinfo_t* tinfo, const config_t* config,
      */
     tinfo->max_outstanding = per_thread(config->max_outstanding,
         config->threads, offset);
-    tinfo->max_qps = per_thread(config->max_qps, config->threads, offset);
-    tinfo->nsocks  = per_thread(config->clients, config->threads, offset);
+    tinfo->max_qps         = per_thread(config->max_qps, config->threads, offset);
+    tinfo->nsocks          = per_thread(config->clients, config->threads, offset);
 
     /*
      * We can't have more than 64k outstanding queries per thread.
@@ -1117,7 +1117,7 @@ threadinfo_init(threadinfo_t* tinfo, const config_t* config,
     socket_offset = 0;
     for (i = 0; i < offset; i++)
         socket_offset += threads[i].nsocks;
-    for (i              = 0; i < tinfo->nsocks; i++)
+    for (i = 0; i < tinfo->nsocks; i++)
         tinfo->socks[i] = perf_net_opensocket(config->mode, &config->server_addr,
             &config->local_addr,
             socket_offset++,
@@ -1159,7 +1159,7 @@ int main(int argc, char** argv)
     threadinfo_t           stats_thread;
     unsigned int           i;
     isc_result_t           result;
-    struct perf_net_socket sock = {.mode = sock_pipe };
+    struct perf_net_socket sock = { .mode = sock_pipe };
 
     printf("DNS Performance Testing Tool\n"
            "Version " PACKAGE_VERSION "\n\n");
@@ -1205,7 +1205,7 @@ int main(int argc, char** argv)
     if (config.timelimit > 0)
         times.stop_time = times.start_time + config.timelimit;
     else
-        times.stop_time        = ISC_UINT64_MAX;
+        times.stop_time = ISC_UINT64_MAX;
     times.stop_time_ns.tv_sec  = times.stop_time / MILLION;
     times.stop_time_ns.tv_nsec = (times.stop_time % MILLION) * 1000;
 

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -389,10 +389,14 @@ setup(int argc, char** argv, config_t* config)
     isc_result_t result;
     const char*  mode = 0;
 
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     dns_result_register();
 

--- a/src/net.c
+++ b/src/net.c
@@ -119,7 +119,7 @@ struct perf_net_socket perf_net_opensocket(enum perf_net_mode mode, const isc_so
     int                    port;
     int                    ret;
     int                    flags;
-    struct perf_net_socket sock = {.mode = mode, .is_ready = 1 };
+    struct perf_net_socket sock = { .mode = mode, .is_ready = 1 };
 
     family = isc_sockaddr_pf(server);
 

--- a/src/net.h
+++ b/src/net.h
@@ -49,6 +49,7 @@ struct perf_net_socket {
 ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags);
 ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags,
     const struct sockaddr* dest_addr, socklen_t addrlen);
+
 int perf_net_close(struct perf_net_socket* sock);
 int perf_net_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b);
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -228,10 +228,14 @@ setup(int argc, char** argv)
     isc_result_t result;
     const char*  _mode = 0;
 
+#ifdef HAVE_ISC_MEM_CREATE_RESULT
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
             isc_result_totext(result));
+#else
+    isc_mem_create(&mctx);
+#endif
 
     dns_result_register();
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -353,7 +353,7 @@ setup(int argc, char** argv)
     socks = isc_mem_get(mctx, nsocks * sizeof(*socks));
     if (socks == NULL)
         perf_log_fatal("out of memory");
-    for (i       = 0; i < nsocks; i++)
+    for (i = 0; i < nsocks; i++)
         socks[i] = perf_net_opensocket(mode, &server_addr, &local_addr, i, bufsize);
 }
 


### PR DESCRIPTION
- Close #71: Pull @pemensik changes to add other
- Fix #67: Workaround for BIND 9.16
- Fix #23: Remove use of static libcrypto
- Update formatting based on latest `clang-format`