### PR TITLE
strerror

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,8 +29,8 @@ EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 bin_PROGRAMS = dnsperf resperf
 dist_bin_SCRIPTS = resperf-report
 
-_libperf_sources = datafile.c dns.c log.c net.c opt.c os.c
-_libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h
+_libperf_sources = datafile.c dns.c log.c net.c opt.c os.c strerror.c
+_libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h strerror.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -378,15 +378,15 @@ stringify(unsigned int value)
 static void
 setup(int argc, char** argv, config_t* config)
 {
-    const char*  family      = NULL;
-    const char*  server_name = DEFAULT_SERVER_NAME;
-    in_port_t    server_port = 0;
-    const char*  local_name  = NULL;
-    in_port_t    local_port  = DEFAULT_LOCAL_PORT;
-    const char*  filename    = NULL;
-    const char*  edns_option = NULL;
-    const char*  tsigkey     = NULL;
-    const char*  mode = 0;
+    const char* family      = NULL;
+    const char* server_name = DEFAULT_SERVER_NAME;
+    in_port_t   server_port = 0;
+    const char* local_name  = NULL;
+    in_port_t   local_port  = DEFAULT_LOCAL_PORT;
+    const char* filename    = NULL;
+    const char* edns_option = NULL;
+    const char* tsigkey     = NULL;
+    const char* mode        = 0;
 
 #ifdef HAVE_ISC_MEM_CREATE_RESULT
     isc_result_t result = isc_mem_create(0, 0, &mctx);
@@ -720,7 +720,8 @@ do_send(void* arg)
                 any_inprogress = 1;
             } else {
                 if (config->verbose) {
-                    perf_log_warning("failed to send packet: %s", strerror(errno));
+                    char __s[256];
+                    perf_log_warning("failed to send packet: %s", perf_strerror_r(errno, __s, sizeof(__s)));
                 }
                 LOCK(&tinfo->lock);
                 query_move(tinfo, q, prepend_unused);
@@ -983,8 +984,8 @@ do_recv(void* arg)
                 now = get_time();
                 continue;
             } else {
-                perf_log_fatal("failed to receive packet: %s",
-                    strerror(saved_errno));
+                char __s[256];
+                perf_log_fatal("failed to receive packet: %s", perf_strerror_r(saved_errno, __s, sizeof(__s)));
             }
         }
     }

--- a/src/os.c
+++ b/src/os.c
@@ -41,7 +41,8 @@ void perf_os_blocksignal(int sig, bool block)
     op = block ? SIG_BLOCK : SIG_UNBLOCK;
 
     if (sigemptyset(&sset) < 0 || sigaddset(&sset, sig) < 0 || pthread_sigmask(op, &sset, NULL) < 0) {
-        perf_log_fatal("pthread_sigmask: %s", strerror(errno));
+        char __s[256];
+        perf_log_fatal("pthread_sigmask: %s", perf_strerror_r(errno, __s, sizeof(__s)));
     }
 }
 
@@ -53,7 +54,8 @@ void perf_os_handlesignal(int sig, void (*handler)(int))
     sa.sa_handler = handler;
 
     if (sigfillset(&sa.sa_mask) < 0 || sigaction(sig, &sa, NULL) < 0) {
-        perf_log_fatal("sigaction: %s", strerror(errno));
+        char __s[256];
+        perf_log_fatal("sigaction: %s", perf_strerror_r(errno, __s, sizeof(__s)));
     }
 }
 
@@ -95,8 +97,10 @@ perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, i
     }
     n = select(maxfd + 1, &read_fds, NULL, NULL, tvp);
     if (n < 0) {
-        if (errno != EINTR)
-            perf_log_fatal("select(): %s", strerror(errno));
+        if (errno != EINTR) {
+            char __s[256];
+            perf_log_fatal("select(): %s", perf_strerror_r(errno, __s, sizeof(__s)));
+        }
         return (ISC_R_CANCELED);
     } else if (n == 0) {
         return (ISC_R_TIMEDOUT);
@@ -138,8 +142,10 @@ perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, i
     }
     n = select(maxfd + 1, &read_fds, &write_fds, NULL, tvp);
     if (n < 0) {
-        if (errno != EINTR)
-            perf_log_fatal("select(): %s", strerror(errno));
+        if (errno != EINTR) {
+            char __s[256];
+            perf_log_fatal("select(): %s", perf_strerror_r(errno, __s, sizeof(__s)));
+        }
         return (ISC_R_CANCELED);
     } else if (n == 0) {
         return (ISC_R_TIMEDOUT);

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -499,7 +499,8 @@ do_one_line(isc_buffer_t* lines, isc_buffer_t* msg)
                 }
             } else {
                 if (verbose) {
-                    perf_log_warning("failed to send packet: %s", strerror(errno));
+                    char __s[256];
+                    perf_log_warning("failed to send packet: %s", perf_strerror_r(errno, __s, sizeof(__s)));
                 }
             }
             return (ISC_R_FAILURE);
@@ -551,7 +552,8 @@ do_one_line(isc_buffer_t* lines, isc_buffer_t* msg)
             }
         } else {
             if (verbose) {
-                perf_log_warning("failed to send packet: %s", strerror(errno));
+                char __s[256];
+                perf_log_warning("failed to send packet: %s", perf_strerror_r(errno, __s, sizeof(__s)));
             }
         }
         return (ISC_R_FAILURE);
@@ -608,8 +610,8 @@ try_process_response(unsigned int sockindex)
         if (errno == EAGAIN || errno == EINTR) {
             return;
         } else {
-            perf_log_fatal("failed to receive packet: %s",
-                strerror(errno));
+            char __s[256];
+            perf_log_fatal("failed to receive packet: %s", perf_strerror_r(errno, __s, sizeof(__s)));
         }
     } else if (!n) {
         // Treat connection closed like try again until reconnection features are in
@@ -786,8 +788,8 @@ end_loop:
 
     plotf = fopen(plotfile, "w");
     if (!plotf) {
-        perf_log_fatal("could not open %s: %s", plotfile,
-            strerror(errno));
+        char __s[256];
+        perf_log_fatal("could not open %s: %s", plotfile, perf_strerror_r(errno, __s, sizeof(__s)));
     }
 
     /* Print column headers */

--- a/src/strerror.c
+++ b/src/strerror.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019-2020 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+
+#include <string.h>
+#include <stdio.h>
+
+const char* perf_strerror_r(int errnum, char* str, size_t len)
+{
+#if ((_POSIX_C_SOURCE >= 200112L) && !_GNU_SOURCE) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+    if (strerror_r(errnum, str, len)) {
+        (void)snprintf(str, len, "Error %d", errnum);
+    }
+    return str;
+#else
+    return strerror_r(errnum, str, len);
+#endif
+}

--- a/src/strerror.h
+++ b/src/strerror.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019-2020 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef PERF_STRERROR_H
+#define PERF_STRERROR_H 1
+
+const char* perf_strerror_r(int errnum, char* str, size_t len);
+
+#endif

--- a/src/util.h
+++ b/src/util.h
@@ -27,102 +27,114 @@
 #include <isc/types.h>
 
 #include "log.h"
+#include "strerror.h"
 
 #ifndef PERF_UTIL_H
 #define PERF_UTIL_H 1
 
 #define MILLION ((uint64_t)1000000)
 
-#define THREAD(thread, start, arg)                                      \
-    do {                                                                \
-        int __n = pthread_create((thread), NULL, (start), (arg));       \
-        if (__n != 0) {                                                 \
-            perf_log_fatal("pthread_create failed: %s", strerror(__n)); \
-        }                                                               \
+#define THREAD(thread, start, arg)                                                               \
+    do {                                                                                         \
+        int __n = pthread_create((thread), NULL, (start), (arg));                                \
+        if (__n != 0) {                                                                          \
+            char __s[256];                                                                       \
+            perf_log_fatal("pthread_create failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                        \
     } while (0)
 
-#define JOIN(thread, valuep)                                          \
-    do {                                                              \
-        int __n = pthread_join((thread), (valuep));                   \
-        if (__n != 0) {                                               \
-            perf_log_fatal("pthread_join failed: %s", strerror(__n)); \
-        }                                                             \
+#define JOIN(thread, valuep)                                                                   \
+    do {                                                                                       \
+        int __n = pthread_join((thread), (valuep));                                            \
+        if (__n != 0) {                                                                        \
+            char __s[256];                                                                     \
+            perf_log_fatal("pthread_join failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                      \
     } while (0)
 
-#define MUTEX_INIT(mutex)                                                   \
-    do {                                                                    \
-        int __n = pthread_mutex_init((mutex), NULL);                        \
-        if (__n != 0) {                                                     \
-            perf_log_fatal("pthread_mutex_init failed: %s", strerror(__n)); \
-        }                                                                   \
+#define MUTEX_INIT(mutex)                                                                            \
+    do {                                                                                             \
+        int __n = pthread_mutex_init((mutex), NULL);                                                 \
+        if (__n != 0) {                                                                              \
+            char __s[256];                                                                           \
+            perf_log_fatal("pthread_mutex_init failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                            \
     } while (0)
 
-#define MUTEX_DESTROY(mutex)                                                   \
-    do {                                                                       \
-        int __n = pthread_mutex_destroy((mutex));                              \
-        if (__n != 0) {                                                        \
-            perf_log_fatal("pthread_mutex_destroy failed: %s", strerror(__n)); \
-        }                                                                      \
+#define MUTEX_DESTROY(mutex)                                                                            \
+    do {                                                                                                \
+        int __n = pthread_mutex_destroy((mutex));                                                       \
+        if (__n != 0) {                                                                                 \
+            char __s[256];                                                                              \
+            perf_log_fatal("pthread_mutex_destroy failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                               \
     } while (0)
 
-#define LOCK(mutex)                                                         \
-    do {                                                                    \
-        int __n = pthread_mutex_lock((mutex));                              \
-        if (__n != 0) {                                                     \
-            perf_log_fatal("pthread_mutex_lock failed: %s", strerror(__n)); \
-        }                                                                   \
+#define LOCK(mutex)                                                                                  \
+    do {                                                                                             \
+        int __n = pthread_mutex_lock((mutex));                                                       \
+        if (__n != 0) {                                                                              \
+            char __s[256];                                                                           \
+            perf_log_fatal("pthread_mutex_lock failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                            \
     } while (0)
 
-#define UNLOCK(mutex)                                                         \
-    do {                                                                      \
-        int __n = pthread_mutex_unlock((mutex));                              \
-        if (__n != 0) {                                                       \
-            perf_log_fatal("pthread_mutex_unlock failed: %s", strerror(__n)); \
-        }                                                                     \
+#define UNLOCK(mutex)                                                                                  \
+    do {                                                                                               \
+        int __n = pthread_mutex_unlock((mutex));                                                       \
+        if (__n != 0) {                                                                                \
+            char __s[256];                                                                             \
+            perf_log_fatal("pthread_mutex_unlock failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                              \
     } while (0)
 
-#define COND_INIT(cond)                                                    \
-    do {                                                                   \
-        int __n = pthread_cond_init((cond), NULL);                         \
-        if (__n != 0) {                                                    \
-            perf_log_fatal("pthread_cond_init failed: %s", strerror(__n)); \
-        }                                                                  \
+#define COND_INIT(cond)                                                                             \
+    do {                                                                                            \
+        int __n = pthread_cond_init((cond), NULL);                                                  \
+        if (__n != 0) {                                                                             \
+            char __s[256];                                                                          \
+            perf_log_fatal("pthread_cond_init failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                           \
     } while (0)
 
-#define SIGNAL(cond)                                                         \
-    do {                                                                     \
-        int __n = pthread_cond_signal((cond));                               \
-        if (__n != 0) {                                                      \
-            perf_log_fatal("pthread_cond_signal failed: %s", strerror(__n)); \
-        }                                                                    \
+#define SIGNAL(cond)                                                                                  \
+    do {                                                                                              \
+        int __n = pthread_cond_signal((cond));                                                        \
+        if (__n != 0) {                                                                               \
+            char __s[256];                                                                            \
+            perf_log_fatal("pthread_cond_signal failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                             \
     } while (0)
 
-#define BROADCAST(cond)                                                         \
-    do {                                                                        \
-        int __n = pthread_cond_broadcast((cond));                               \
-        if (__n != 0) {                                                         \
-            perf_log_fatal("pthread_cond_broadcast failed: %s", strerror(__n)); \
-        }                                                                       \
+#define BROADCAST(cond)                                                                                  \
+    do {                                                                                                 \
+        int __n = pthread_cond_broadcast((cond));                                                        \
+        if (__n != 0) {                                                                                  \
+            char __s[256];                                                                               \
+            perf_log_fatal("pthread_cond_broadcast failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                                \
     } while (0)
 
-#define WAIT(cond, mutex)                                                  \
-    do {                                                                   \
-        int __n = pthread_cond_wait((cond), (mutex));                      \
-        if (__n != 0) {                                                    \
-            perf_log_fatal("pthread_cond_wait failed: %s", strerror(__n)); \
-        }                                                                  \
+#define WAIT(cond, mutex)                                                                           \
+    do {                                                                                            \
+        int __n = pthread_cond_wait((cond), (mutex));                                               \
+        if (__n != 0) {                                                                             \
+            char __s[256];                                                                          \
+            perf_log_fatal("pthread_cond_wait failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                           \
     } while (0)
 
-#define TIMEDWAIT(cond, mutex, when, timedout)                                  \
-    do {                                                                        \
-        int   __n = pthread_cond_timedwait((cond), (mutex), (when));            \
-        bool* res = (timedout);                                                 \
-        if (__n != 0 && __n != ETIMEDOUT) {                                     \
-            perf_log_fatal("pthread_cond_timedwait failed: %s", strerror(__n)); \
-        }                                                                       \
-        if (res != NULL) {                                                      \
-            *res = (__n != 0);                                                  \
-        }                                                                       \
+#define TIMEDWAIT(cond, mutex, when, timedout)                                                           \
+    do {                                                                                                 \
+        int   __n = pthread_cond_timedwait((cond), (mutex), (when));                                     \
+        bool* res = (timedout);                                                                          \
+        if (__n != 0 && __n != ETIMEDOUT) {                                                              \
+            char __s[256];                                                                               \
+            perf_log_fatal("pthread_cond_timedwait failed: %s", perf_strerror_r(__n, __s, sizeof(__s))); \
+        }                                                                                                \
+        if (res != NULL) {                                                                               \
+            *res = (__n != 0);                                                                           \
+        }                                                                                                \
     } while (0)
 
 static __inline__ uint64_t


### PR DESCRIPTION
- Fix #31: Add `perf_strerror_r()` to use thread-safe XSI/GNU `strerror_r()`