### PR TITLE
Coverage

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,6 +44,15 @@ AC_ARG_WITH([extra-ldflags], [AS_HELP_STRING([--with-extra-ldflags=CFLAGS], [Add
   AS_VAR_APPEND(LDFLAGS, [" $withval"])
 ])
 
+# Check --enable-gcov
+AC_ARG_ENABLE([gcov], [AS_HELP_STRING([--enable-gcov], [Enable coverage testing])], [
+  coverage_cflags="--coverage -g -O0 -fno-inline -fno-inline-small-functions -fno-default-inline"
+  AC_MSG_NOTICE([enabling coverage testing... $coverage_cflags])
+  AS_VAR_APPEND(CFLAGS, [" $coverage_cflags"])
+])
+AM_CONDITIONAL([ENABLE_GCOV], [test "x$enable_gcov" != "xno"])
+AM_EXTRA_RECURSIVE_TARGETS([gcov])
+
 # Checks for support.
 AX_PTHREAD
 AC_CHECK_LIB([socket], [socket])
@@ -127,5 +136,6 @@ AX_SA_LEN
 AC_CONFIG_FILES([
   Makefile
   src/Makefile
+  src/test/Makefile
 ])
 AC_OUTPUT

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,9 +16,9 @@
 # limitations under the License.
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in $(srcdir)/config.h.in
-CLEANFILES = dnsperf.1 resperf.1
+CLEANFILES = dnsperf.1 resperf.1 *.gcda *.gcno *.gcov
 
-SUBDIRS =
+SUBDIRS = test
 
 AM_CFLAGS = -I$(srcdir) \
   -I$(top_srcdir) \
@@ -53,3 +53,10 @@ resperf.1: resperf.1.in Makefile
 -e 's,[@]PACKAGE_URL[@],$(PACKAGE_URL),g' \
 -e 's,[@]PACKAGE_BUGREPORT[@],$(PACKAGE_BUGREPORT),g' \
 < $(srcdir)/resperf.1.in > resperf.1
+
+if ENABLE_GCOV
+gcov-local:
+	for src in $(_libperf_sources) dnsperf.c resperf.c; do \
+	  gcov -l -r -s "$(srcdir)" "$$src"; \
+	done
+endif

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -1,0 +1,7 @@
+4MAINTAINERCLEANFILES = $(srcdir)/Makefile.in
+
+CLEANFILES = test*.log test*.trs
+
+TESTS = test1.sh
+
+EXTRA_DIST = $(TESTS)

--- a/src/test/test1.sh
+++ b/src/test/test1.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -xe
+
+../dnsperf -h
+../resperf -h


### PR DESCRIPTION
- Add `--enable-gcov` and `gcov` make target for Code coverage
- Add small test to just execute `dnsperf` and `resperf`