### PR TITLE
isc_result_t

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,7 +31,7 @@ dist_bin_SCRIPTS = resperf-report
 
 _libperf_sources = datafile.c dns.c log.c net.c opt.c os.c strerror.c
 _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h strerror.h \
-  list.h
+  list.h result.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)

--- a/src/datafile.c
+++ b/src/datafile.c
@@ -143,13 +143,13 @@ reopen_file(perf_datafile_t* dfile)
     }
 }
 
-static isc_result_t
+static perf_result_t
 read_more(perf_datafile_t* dfile)
 {
     unsigned char*         data;
     size_t                 size;
     ssize_t                n;
-    isc_result_t           result;
+    perf_result_t          result;
     struct perf_net_socket sock = { .mode = sock_file, .fd = dfile->fd };
 
     if (!dfile->is_file && dfile->pipe_fd >= 0) {
@@ -175,12 +175,12 @@ read_more(perf_datafile_t* dfile)
     return (ISC_R_SUCCESS);
 }
 
-static isc_result_t
+static perf_result_t
 read_one_line(perf_datafile_t* dfile, isc_buffer_t* lines)
 {
-    const char*  cur;
-    unsigned int length, curlen, nrem;
-    isc_result_t result;
+    const char*   cur;
+    unsigned int  length, curlen, nrem;
+    perf_result_t result;
 
     while (ISC_TRUE) {
         /* Get the current line */
@@ -225,12 +225,12 @@ read_one_line(perf_datafile_t* dfile, isc_buffer_t* lines)
     return (ISC_R_SUCCESS);
 }
 
-isc_result_t
+perf_result_t
 perf_datafile_next(perf_datafile_t* dfile, isc_buffer_t* lines,
     bool is_update)
 {
-    const char*  current;
-    isc_result_t result;
+    const char*   current;
+    perf_result_t result;
 
     LOCK(&dfile->lock);
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -42,7 +42,6 @@
 #include <isc/mem.h>
 #include <isc/parseint.h>
 #include <isc/region.h>
-#include <isc/result.h>
 #include <isc/util.h>
 
 #include <dns/callbacks.h>
@@ -131,7 +130,7 @@ perf_dns_createctx(bool updates)
 {
     isc_mem_t*     mctx;
     perf_dnsctx_t* ctx;
-    isc_result_t   result;
+    perf_result_t  result;
 
     if (!updates)
         return NULL;
@@ -141,7 +140,7 @@ perf_dns_createctx(bool updates)
     result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
-            isc_result_totext(result));
+            perf_result_totext(result));
 #else
     isc_mem_create(&mctx);
 #endif
@@ -158,13 +157,13 @@ perf_dns_createctx(bool updates)
     result = dns_compress_init(&ctx->compress, 0, ctx->mctx);
     if (result != ISC_R_SUCCESS) {
         perf_log_fatal("creating compression context: %s",
-            isc_result_totext(result));
+            perf_result_totext(result));
     }
     dns_compress_setmethods(&ctx->compress, DNS_COMPRESS_GLOBAL14);
 
     result = isc_lex_create(ctx->mctx, 1024, &ctx->lexer);
     if (result != ISC_R_SUCCESS) {
-        perf_log_fatal("creating lexer: %s", isc_result_totext(result));
+        perf_log_fatal("creating lexer: %s", perf_result_totext(result));
     }
 
     return (ctx);
@@ -189,13 +188,13 @@ void perf_dns_destroyctx(perf_dnsctx_t** ctxp)
     isc_mem_destroy(&mctx);
 }
 
-static isc_result_t
+static perf_result_t
 name_fromstring(dns_name_t* name, const dns_name_t* origin,
     const char* str, unsigned int len,
     isc_buffer_t* target, const char* type)
 {
-    isc_buffer_t buffer;
-    isc_result_t result;
+    isc_buffer_t  buffer;
+    perf_result_t result;
 
     isc_buffer_constinit(&buffer, str, len);
     isc_buffer_add(&buffer, len);
@@ -219,7 +218,7 @@ perf_dns_parsetsigkey(const char* arg, isc_mem_t* mctx)
     perf_dnstsigkey_t* tsigkey;
     const char *       sep1, *sep2, *alg, *name, *secret;
     int                alglen, namelen;
-    isc_result_t       result;
+    perf_result_t      result;
 
     tsigkey = isc_mem_get(mctx, sizeof(*tsigkey));
     if (tsigkey == NULL) {
@@ -352,7 +351,7 @@ perf_dns_parseednsoption(const char* arg, isc_mem_t* mctx)
     perf_dnsednsoption_t* option;
     uint16_t              code;
     isc_buffer_t          save;
-    isc_result_t          result;
+    perf_result_t         result;
 
     copy = isc_mem_strdup(mctx, arg);
     if (copy == NULL) {
@@ -423,7 +422,7 @@ void perf_dns_destroyednsoption(perf_dnsednsoption_t** optionp)
 /*
  * Appends an OPT record to the packet.
  */
-static isc_result_t
+static perf_result_t
 add_edns(isc_buffer_t* packet, bool dnssec,
     perf_dnsednsoption_t* option)
 {
@@ -622,7 +621,7 @@ hmac_sign(perf_dnstsigkey_t* tsigkey, hmac_ctx_t* ctx, unsigned char* digest,
 /*
  * Appends a TSIG record to the packet.
  */
-static isc_result_t
+static perf_result_t
 add_tsig(isc_buffer_t* packet, perf_dnstsigkey_t* tsigkey)
 {
     unsigned char* base;
@@ -690,7 +689,7 @@ add_tsig(isc_buffer_t* packet, perf_dnstsigkey_t* tsigkey)
     return (ISC_R_SUCCESS);
 }
 
-static isc_result_t
+static perf_result_t
 build_query(const isc_textregion_t* line, isc_buffer_t* msg)
 {
     char*            domain_str;
@@ -699,7 +698,7 @@ build_query(const isc_textregion_t* line, isc_buffer_t* msg)
     dns_offsets_t    offsets;
     isc_textregion_t qtype_r;
     dns_rdatatype_t  qtype;
-    isc_result_t     result;
+    perf_result_t    result;
 
     domain_str = line->base;
     domain_len = strcspn(line->base, WHITESPACE);
@@ -742,7 +741,7 @@ token_equals(const isc_textregion_t* token, const char* str)
 /*
  * Reads one line containing an individual update for a dynamic update message.
  */
-static isc_result_t
+static perf_result_t
 read_update_line(perf_dnsctx_t* ctx, const isc_textregion_t* line, char* str,
     dns_name_t* zname, int want_ttl, int need_type,
     int want_rdata, int need_rdata, dns_name_t* name,
@@ -754,7 +753,7 @@ read_update_line(perf_dnsctx_t* ctx, const isc_textregion_t* line, char* str,
     isc_buffer_t         buffer;
     isc_textregion_t     src;
     dns_rdatacallbacks_t callbacks;
-    isc_result_t         result;
+    perf_result_t        result;
 
     while (isspace(*str & 0xff))
         str++;
@@ -820,7 +819,7 @@ read_update_line(perf_dnsctx_t* ctx, const isc_textregion_t* line, char* str,
     isc_buffer_add(&buffer, strlen(str));
     result = isc_lex_openbuffer(ctx->lexer, &buffer);
     if (result != ISC_R_SUCCESS) {
-        perf_log_warning("setting up lexer: %s", isc_result_totext(result));
+        perf_log_warning("setting up lexer: %s", perf_result_totext(result));
         return (result);
     }
     dns_rdatacallbacks_init_stdio(&callbacks);
@@ -838,7 +837,7 @@ read_update_line(perf_dnsctx_t* ctx, const isc_textregion_t* line, char* str,
 /*
  * Reads a complete dynamic update message and sends it.
  */
-static isc_result_t
+static perf_result_t
 build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
     isc_buffer_t* msg)
 {
@@ -858,7 +857,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
     dns_rdataclass_t rdclass;
     dns_rdata_t      rdata;
     uint16_t         rdlen;
-    isc_result_t     result;
+    perf_result_t    result;
 
     /* Reset compression context */
     dns_compress_rollback(&ctx->compress, 0);
@@ -891,7 +890,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
     result = dns_name_towire(zname, &ctx->compress, msg);
     if (result != ISC_R_SUCCESS) {
         perf_log_warning("error rendering zone name: %s",
-            isc_result_totext(result));
+            perf_result_totext(result));
         goto done;
     }
     isc_buffer_putuint16(msg, dns_rdatatype_soa);
@@ -968,7 +967,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
         result = dns_name_towire(oname, &ctx->compress, msg);
         if (result != ISC_R_SUCCESS) {
             perf_log_warning("rendering record name: %s",
-                isc_result_totext(result));
+                perf_result_totext(result));
             goto done;
         }
         if (isc_buffer_availablelength(msg) < 10) {
@@ -987,7 +986,7 @@ build_update(perf_dnsctx_t* ctx, const isc_textregion_t* record,
             result = dns_rdata_towire(&rdata, &ctx->compress, msg);
             if (result != ISC_R_SUCCESS) {
                 perf_log_warning("rendering rdata: %s",
-                    isc_result_totext(result));
+                    perf_result_totext(result));
                 goto done;
             }
             rdlen = msg->used - rdlenbuf.used - 2;
@@ -1008,15 +1007,15 @@ done:
     return result;
 }
 
-isc_result_t
+perf_result_t
 perf_dns_buildrequest(perf_dnsctx_t* ctx, const isc_textregion_t* record,
     uint16_t qid,
     bool edns, bool dnssec,
     perf_dnstsigkey_t* tsigkey, perf_dnsednsoption_t* option,
     isc_buffer_t* msg)
 {
-    unsigned int flags;
-    isc_result_t result;
+    unsigned int  flags;
+    perf_result_t result;
 
     if (ctx != NULL)
         flags = dns_opcode_update << 11;

--- a/src/dns.h
+++ b/src/dns.h
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
-#include <isc/types.h>
+#include "result.h"
 
 #ifndef PERF_DNS_H
 #define PERF_DNS_H 1
+
+#include <isc/types.h>
 
 #define MAX_UDP_PACKET 512
 #define MAX_EDNS_PACKET 4096
@@ -46,7 +48,7 @@ perf_dns_createctx(bool updates);
 
 void perf_dns_destroyctx(perf_dnsctx_t** ctxp);
 
-isc_result_t
+perf_result_t
 perf_dns_buildrequest(perf_dnsctx_t* ctx, const isc_textregion_t* record,
     uint16_t qid,
     bool edns, bool dnssec,

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -47,7 +47,6 @@
 #include <isc/netaddr.h>
 #include <isc/print.h>
 #include <isc/region.h>
-#include <isc/result.h>
 #include <isc/sockaddr.h>
 #include <isc/types.h>
 
@@ -388,10 +387,10 @@ setup(int argc, char** argv, config_t* config)
     const char* mode        = 0;
 
 #ifdef HAVE_ISC_MEM_CREATE_RESULT
-    isc_result_t result = isc_mem_create(0, 0, &mctx);
+    perf_result_t result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
-            isc_result_totext(result));
+            perf_result_totext(result));
 #else
     isc_mem_create(&mctx);
 #endif
@@ -594,7 +593,7 @@ do_send(void* arg)
     unsigned char*  base;
     unsigned int    length;
     int             n, i, any_inprogress = 0;
-    isc_result_t    result;
+    perf_result_t   result;
 
     tinfo           = (threadinfo_t*)arg;
     config          = tinfo->config;
@@ -1157,7 +1156,7 @@ int main(int argc, char** argv)
     stats_t                total_stats;
     threadinfo_t           stats_thread;
     unsigned int           i;
-    isc_result_t           result;
+    perf_result_t          result;
     struct perf_net_socket sock = { .mode = sock_pipe };
 
     printf("DNS Performance Testing Tool\n"

--- a/src/list.h
+++ b/src/list.h
@@ -22,56 +22,70 @@
 
 #include <assert.h>
 
-#define perf_link(type) struct { type *prev, *next; } _link
-#define perf_link_init(link) { (link)->_link.prev = 0; (link)->_link.next = 0; }
+#define perf_link(type)    \
+    struct {               \
+        type *prev, *next; \
+    } _link
+#define perf_link_init(link)    \
+    {                           \
+        (link)->_link.prev = 0; \
+        (link)->_link.next = 0; \
+    }
 
-#define perf_list(type) struct { type *head, *tail; }
-#define perf_list_init(list) { (list).head = 0; (list).tail = 0; }
+#define perf_list(type)    \
+    struct {               \
+        type *head, *tail; \
+    }
+#define perf_list_init(list) \
+    {                        \
+        (list).head = 0;     \
+        (list).tail = 0;     \
+    }
 
 #define perf_list_head(list) ((list).head)
 #define perf_list_tail(list) ((list).tail)
 #define perf_list_empty(list) (!(list).head)
 
-#define perf_list_append(list, link) \
-    { \
-        if ((list).tail) { \
+#define perf_list_append(list, link)          \
+    {                                         \
+        if ((list).tail) {                    \
             (list).tail->_link.next = (link); \
-        } else { \
-            (list).head = (link); \
-        } \
-        (link)->_link.prev = (list).tail; \
-        (link)->_link.next = 0; \
-        (list).tail = (link); \
+        } else {                              \
+            (list).head = (link);             \
+        }                                     \
+        (link)->_link.prev = (list).tail;     \
+        (link)->_link.next = 0;               \
+        (list).tail        = (link);          \
     }
-#define perf_list_prepend(list, link) \
-    { \
-        if ((list).head) { \
+#define perf_list_prepend(list, link)         \
+    {                                         \
+        if ((list).head) {                    \
             (list).head->_link.prev = (link); \
-        } else { \
-            (list).tail = (link); \
-        } \
-        (link)->_link.prev = 0; \
-        (link)->_link.next = (list).head; \
-        (list).head= (link); \
+        } else {                              \
+            (list).tail = (link);             \
+        }                                     \
+        (link)->_link.prev = 0;               \
+        (link)->_link.next = (list).head;     \
+        (list).head        = (link);          \
     }
-#define perf_list_unlink(list, link) \
-    { \
-        if ((link)->_link.next) { \
+#define perf_list_unlink(list, link)                             \
+    {                                                            \
+        if ((link)->_link.next) {                                \
             (link)->_link.next->_link.prev = (link)->_link.prev; \
-        } else { \
-            assert((list).tail == (link)); \
-            (list).tail = (link)->_link.prev; \
-        } \
-        if ((link)->_link.prev) { \
+        } else {                                                 \
+            assert((list).tail == (link));                       \
+            (list).tail = (link)->_link.prev;                    \
+        }                                                        \
+        if ((link)->_link.prev) {                                \
             (link)->_link.prev->_link.next = (link)->_link.next; \
-        } else { \
-            assert((list).head == (link)); \
-            (list).head = (link)->_link.next; \
-        } \
-        (link)->_link.next = 0; \
-        (link)->_link.prev = 0; \
-        assert((list).head != (link)); \
-        assert((list).tail != (link)); \
+        } else {                                                 \
+            assert((list).head == (link));                       \
+            (list).head = (link)->_link.next;                    \
+        }                                                        \
+        (link)->_link.next = 0;                                  \
+        (link)->_link.prev = 0;                                  \
+        assert((list).head != (link));                           \
+        assert((list).tail != (link));                           \
     }
 
 #endif

--- a/src/net.c
+++ b/src/net.c
@@ -28,7 +28,6 @@
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
-#include <isc/result.h>
 #include <isc/sockaddr.h>
 
 #include <bind9/getaddresses.h>
@@ -68,7 +67,7 @@ void perf_net_parseserver(int family, const char* name, unsigned int port,
 {
     isc_sockaddr_t addrs[8];
     int            count, i;
-    isc_result_t   result;
+    perf_result_t  result;
 
     if (port == 0) {
         fprintf(stderr, "server port cannot be 0\n");

--- a/src/opt.c
+++ b/src/opt.c
@@ -28,11 +28,11 @@
 
 #include <isc/file.h>
 #include <isc/parseint.h>
-#include <isc/result.h>
 
 #include "log.h"
 #include "opt.h"
 #include "util.h"
+#include "result.h"
 
 #define MAX_OPTS 64
 #define LINE_LENGTH 80
@@ -125,8 +125,8 @@ static uint32_t
 parse_uint(const char* desc, const char* str,
     unsigned int min, unsigned int max)
 {
-    uint32_t     val;
-    isc_result_t result;
+    uint32_t      val;
+    perf_result_t result;
 
     val    = 0;
     result = isc_parse_uint32(&val, str, 10);

--- a/src/os.c
+++ b/src/os.c
@@ -26,7 +26,6 @@
 
 #include <sys/select.h>
 
-#include <isc/result.h>
 #include <isc/types.h>
 
 #include "log.h"
@@ -59,13 +58,13 @@ void perf_os_handlesignal(int sig, void (*handler)(int))
     }
 }
 
-isc_result_t
+perf_result_t
 perf_os_waituntilreadable(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
 {
     return perf_os_waituntilanyreadable(sock, 1, pipe_fd, timeout);
 }
 
-isc_result_t
+perf_result_t
 perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
     int64_t timeout)
 {
@@ -111,7 +110,7 @@ perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, i
     }
 }
 
-isc_result_t
+perf_result_t
 perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
     int64_t timeout)
 {

--- a/src/os.h
+++ b/src/os.h
@@ -18,6 +18,7 @@
  */
 
 #include "net.h"
+#include "result.h"
 
 #ifndef PERF_OS_H
 #define PERF_OS_H 1
@@ -29,14 +30,14 @@ void perf_os_blocksignal(int sig, bool block);
 
 void perf_os_handlesignal(int sig, void (*handler)(int));
 
-isc_result_t
+perf_result_t
 perf_os_waituntilreadable(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
 
-isc_result_t
+perf_result_t
 perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 
-isc_result_t
+perf_result_t
 perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -40,7 +40,6 @@
 #include <isc/mem.h>
 #include <isc/print.h>
 #include <isc/region.h>
-#include <isc/result.h>
 #include <isc/sockaddr.h>
 #include <isc/types.h>
 
@@ -54,6 +53,7 @@
 #include "util.h"
 #include "os.h"
 #include "list.h"
+#include "result.h"
 
 /*
  * Global stuff
@@ -227,10 +227,10 @@ setup(int argc, char** argv)
     const char*  _mode = 0;
 
 #ifdef HAVE_ISC_MEM_CREATE_RESULT
-    isc_result_t result = isc_mem_create(0, 0, &mctx);
+    perf_result_t result = isc_mem_create(0, 0, &mctx);
     if (result != ISC_R_SUCCESS)
         perf_log_fatal("creating memory context: %s",
-            isc_result_totext(result));
+            perf_result_totext(result));
 #else
     isc_mem_create(&mctx);
 #endif
@@ -467,7 +467,7 @@ init_buckets(int n)
  * Send a query based on a line of input.
  * Return ISC_R_NOMORE if we ran out of query IDs.
  */
-static isc_result_t
+static perf_result_t
 do_one_line(isc_buffer_t* lines, isc_buffer_t* msg)
 {
     query_info*    q;
@@ -476,7 +476,7 @@ do_one_line(isc_buffer_t* lines, isc_buffer_t* msg)
     isc_region_t   used;
     unsigned char* base;
     unsigned int   length;
-    isc_result_t   result;
+    perf_result_t  result;
 
     isc_buffer_clear(lines);
     result = perf_datafile_next(input, lines, false);
@@ -697,7 +697,7 @@ int main(int argc, char** argv)
     unsigned char outpacket_buffer[MAX_EDNS_PACKET];
     unsigned int  max_packet_size;
     unsigned int  current_sock;
-    isc_result_t  result;
+    perf_result_t result;
 
     printf("DNS Resolution Performance Testing Tool\n"
            "Version " PACKAGE_VERSION "\n\n");

--- a/src/result.h
+++ b/src/result.h
@@ -17,31 +17,22 @@
  * limitations under the License.
  */
 
-#include "result.h"
+#ifndef PERF_RESULT_H
+#define PERF_RESULT_H 1
 
-#ifndef PERF_DATAFILE_H
-#define PERF_DATAFILE_H 1
+#include <isc/result.h>
 
-#include <stdbool.h>
+typedef unsigned int perf_result_t;
 
-#include <isc/types.h>
+#define PERF_R_CANCELED ISC_R_CANCELED
+#define PERF_R_EOF ISC_R_EOF
+#define PERF_R_FAILURE ISC_R_FAILURE
+#define PERF_R_INVALIDFILE ISC_R_INVALIDFILE
+#define PERF_R_NOMORE ISC_R_NOMORE
+#define PERF_R_NOSPACE ISC_R_NOSPACE
+#define PERF_R_SUCCESS ISC_R_SUCCESS
+#define PERF_R_TIMEDOUT ISC_R_TIMEDOUT
 
-typedef struct perf_datafile perf_datafile_t;
-
-perf_datafile_t*
-perf_datafile_open(isc_mem_t* mctx, const char* filename);
-
-void perf_datafile_close(perf_datafile_t** dfilep);
-
-void perf_datafile_setmaxruns(perf_datafile_t* dfile, unsigned int maxruns);
-
-void perf_datafile_setpipefd(perf_datafile_t* dfile, int pipe_fd);
-
-perf_result_t
-perf_datafile_next(perf_datafile_t* dfile, isc_buffer_t* lines,
-    bool is_update);
-
-unsigned int
-perf_datafile_nruns(const perf_datafile_t* dfile);
+#define perf_result_totext(r) isc_result_totext(r)
 
 #endif


### PR DESCRIPTION
- Issue #73:
  - Transition `isc_result_t` to `perf_result_t` using temporary mapping
  - Add `perf_result_totext()` as temporary macro which calls `isc_result_totext()`