### PR TITLE
datafile, query desc

### DIFF
--- a/src/datafile.h
+++ b/src/datafile.h
@@ -23,25 +23,18 @@
 #define PERF_DATAFILE_H 1
 
 #include <stdbool.h>
-
 #include <isc/types.h>
 
 typedef struct perf_datafile perf_datafile_t;
 
-perf_datafile_t*
-perf_datafile_open(isc_mem_t* mctx, const char* filename);
+perf_datafile_t* perf_datafile_open(const char* filename);
 
 void perf_datafile_close(perf_datafile_t** dfilep);
-
 void perf_datafile_setmaxruns(perf_datafile_t* dfile, unsigned int maxruns);
-
 void perf_datafile_setpipefd(perf_datafile_t* dfile, int pipe_fd);
 
-perf_result_t
-perf_datafile_next(perf_datafile_t* dfile, isc_buffer_t* lines,
-    bool is_update);
+perf_result_t perf_datafile_next(perf_datafile_t* dfile, isc_buffer_t* lines, bool is_update);
 
-unsigned int
-perf_datafile_nruns(const perf_datafile_t* dfile);
+unsigned int perf_datafile_nruns(const perf_datafile_t* dfile);
 
 #endif

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -484,7 +484,7 @@ setup(int argc, char** argv, config_t* config)
     perf_net_parselocal(config->server_addr.sa.sa.sa_family,
         local_name, local_port, &config->local_addr);
 
-    input = perf_datafile_open(mctx, filename);
+    input = perf_datafile_open(filename);
 
     if (config->maxruns == 0 && config->timelimit == 0)
         config->maxruns = 1;
@@ -700,6 +700,7 @@ do_send(void* arg)
 
         now = get_time();
         if (config->verbose) {
+            free(q->desc);
             q->desc = strdup(lines.base);
             if (q->desc == NULL)
                 perf_log_fatal("out of memory");

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -340,7 +340,7 @@ setup(int argc, char** argv)
     perf_net_parselocal(server_addr.sa.sa.sa_family, local_name,
         local_port, &local_addr);
 
-    input = perf_datafile_open(mctx, filename);
+    input = perf_datafile_open(filename);
 
     if (dnssec)
         edns = true;


### PR DESCRIPTION
- `datafile`:
  - Issues #73: Remove ISC library dependency when reading datafiles
  - Remove usage of `ISC_TRUE` and `ISC_FALSE`
- `dnsperf`: Fix potential memory leak of query descriptions when using verbose