### PR TITLE
BIND dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,33 +43,19 @@ those queries to DNS servers to measure performance.
 `dnsperf` requires a couple of libraries beside a normal C compiling
 environment with autoconf, automake, libtool and pkgconfig.
 
-`dnsperf` has a non-optional dependency on the BIND library and development
-files along with all dependencies it requires.
-
 To install the dependencies under Debian/Ubuntu:
 ```
-apt-get install -y libbind-dev libkrb5-dev libssl-dev libcap-dev libxml2-dev libjson-c-dev libgeoip-dev
-```
-
-Depending on how BIND is compiled on Debian and Ubuntu you might need these
-dependencies also:
-```
-apt-get install -y libprotobuf-c-dev libfstrm-dev liblmdb-dev libssl-dev
+apt-get install -y libssl-dev
 ```
 
 To install the dependencies under CentOS (with EPEL enabled):
 ```
-yum install -y bind-devel krb5-devel openssl-devel libcap-devel libxml2-devel json-c-devel GeoIP-devel
+yum install -y openssl-devel
 ```
 
 To install the dependencies under FreeBSD 12+ using `pkg`:
 ```
-pkg install -y bind913-9.13.5 openssl-devel GeoIP
-```
-
-To install the dependencies under OpenBSD 6+ using `pkg_add`:
-```
-pkg_add isc-bind-9.11.4pl2 GeoIP
+pkg install -y openssl-devel
 ```
 
 ## Building from source tarball

--- a/configure.ac
+++ b/configure.ac
@@ -55,8 +55,8 @@ AM_EXTRA_RECURSIVE_TARGETS([gcov])
 
 # Checks for support.
 AX_PTHREAD
-AC_CHECK_LIB([socket], [socket])
-AC_CHECK_LIB([nsl], [inet_ntoa])
+# TODO: AC_CHECK_LIB([socket], [socket])
+# TODO: AC_CHECK_LIB([nsl], [inet_ntoa])
 AC_CHECK_LIB([m], [sqrt])
 
 # Check for OpenSSL
@@ -65,70 +65,9 @@ PKG_CHECK_MODULES([libcrypto], [libcrypto]) # also check libcrypto which might b
 AC_CHECK_LIB([ssl], [TLS_client_method],
 	[AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
 
-# Check for bind
-AC_ARG_WITH([bind], [AS_HELP_STRING([--with-bind=PATH], [Specify ISC BIND 9 prefix path])], [
-  use_bind="$withval"
-],[
-  use_bind="yes"
-])
-
-AC_MSG_CHECKING([for BIND 9 libraries])
-if test $use_bind = no; then
-  AC_MSG_ERROR([BIND 9 libraries must be installed])
-elif test $use_bind = yes; then
-  bindpath="$PATH"
-else
-  bindpath="$withval/bin"
-fi
-AC_PATH_PROG(ac_cv_isc_config, [isc-config.sh], [no], [$bindpath])
-if test "$ac_cv_isc_config" = "no"; then
-# BIND 9.16+
-  AC_MSG_NOTICE([Trying BIND 9.16+ workaround...])
-
-  AS_VAR_COPY(old_CFLAGS, CFLAGS)
-  AS_VAR_COPY(old_LDFLAGS, LDFLAGS)
-  AS_VAR_APPEND(CFLAGS, [" $libssl_CFLAGS $libcrypto_CFLAGS"])
-  AS_VAR_APPEND(LDFLAGS, [" $libssl_LIBS $libcrypto_LIBS"])
-  AC_CHECK_LIB([xml2], [xmlNewTextWriter])
-  AC_CHECK_LIB([json-c], [json_object_new_array])
-
-  AC_CHECK_LIB([isc], [isc_mem_create], [], [AC_MSG_ERROR([Please install BIND9 development files])])
-  AC_CHECK_LIB([dns], [dns_name_init], [], [AC_MSG_ERROR([Please install BIND9 development files])])
-  AC_CHECK_LIB([bind9], [bind9_getaddresses], [], [AC_MSG_ERROR([Please install BIND9 development files])])
-  AC_CHECK_HEADER([isc/result.h], [], [AC_MSG_ERROR([Please install BIND9 header files])])
-  AC_CHECK_HEADER([bind9/getaddresses.h], [], [AC_MSG_ERROR([Please install BIND9 header files])])
-
-  AS_VAR_COPY(CFLAGS, old_CFLAGS)
-  AS_VAR_COPY(LDFLAGS, old_LDFLAGS)
-else
-# BIND <= 9.14
-  AS_VAR_APPEND(CFLAGS, [" `$ac_cv_isc_config --cflags dns bind9`"])
-  AS_VAR_APPEND(LDFLAGS, [" `$ac_cv_isc_config --libs dns bind9`"])
-fi
-
-AC_MSG_CHECKING([return type of isc_mem_create])
-returns=undefined
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/mem.h>]],
-      [[ isc_result_t result = isc_mem_create(0, 0, NULL) ]])],
-  [returns=isc_result_t
-   AC_DEFINE([HAVE_ISC_MEM_CREATE_RESULT], [1], [Define to 1 if 'isc_mem_create' returns result])],
-  [returns=void]
-)
-AC_MSG_RESULT([$returns])
-
-AC_MSG_CHECKING([return type of isc_buffer_allocate])
-returns=undefined
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <isc/buffer.h>]],
-      [[ isc_result_t result = isc_buffer_allocate(NULL, NULL, 0) ]])],
-  [returns=isc_result_t
-   AC_DEFINE([HAVE_ISC_BUFFER_ALLOCATE_RESULT], [1], [Define to 1 if 'isc_buffer_allocate' returns result])],
-  [returns=void]
-)
-AC_MSG_RESULT([$returns])
-
-# Checks for sizes
-AX_TYPE_SOCKLEN_T
-AX_SA_LEN
+# TODO: # Checks for sizes
+# AX_TYPE_SOCKLEN_T
+# AX_SA_LEN
 
 # Output Makefiles
 AC_CONFIG_FILES([

--- a/debian/control
+++ b/debian/control
@@ -3,9 +3,7 @@ Section: net
 Priority: optional
 Maintainer: Jerry Lundström <lundstrom.jerry@gmail.com>
 Build-Depends: debhelper (>= 8.0.0), build-essential, automake, autoconf,
- libtool, libbind-dev, libkrb5-dev, libssl-dev, libcap-dev, libxml2-dev,
- libjson-c-dev, libgeoip-dev, libprotobuf-c-dev, libfstrm-dev, liblmdb-dev,
- pkg-config
+ libtool, libssl-dev, pkg-config
 Standards-Version: 3.9.4
 Homepage: https://www.dns-oarc.net/tools/dnsperf
 Vcs-Git: https://github.com/DNS-OARC/dnsperf.git

--- a/rpm/dnsperf.spec
+++ b/rpm/dnsperf.spec
@@ -13,19 +13,7 @@ Source0:        https://www.dns-oarc.net/files/dnsperf/%{name}-%{version}.tar.gz
 BuildRequires:  autoconf
 BuildRequires:  automake
 BuildRequires:  libtool
-BuildRequires:  bind-devel
-BuildRequires:  krb5-devel
 BuildRequires:  openssl-devel
-BuildRequires:  libcap-devel
-BuildRequires:  libxml2-devel
-%if 0%{?suse_version} || 0%{?sle_version}
-BuildRequires:  libjson-c-devel
-%else
-BuildRequires:  json-c-devel
-%endif
-%if 0%{?suse_version} <= 1500
-BuildRequires:  GeoIP-devel
-%endif
 BuildRequires:  pkgconfig
 
 %description

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -29,9 +29,9 @@ EXTRA_DIST = dnsperf.1.in resperf-report resperf.1.in
 bin_PROGRAMS = dnsperf resperf
 dist_bin_SCRIPTS = resperf-report
 
-_libperf_sources = datafile.c dns.c log.c net.c opt.c os.c strerror.c
+_libperf_sources = datafile.c dns.c log.c net.c opt.c os.c strerror.c qtype.c
 _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h strerror.h \
-  list.h result.h buffer.h
+  list.h result.h buffer.h qtype.h
 
 dnsperf_SOURCES = $(_libperf_sources) dnsperf.c
 dist_dnsperf_SOURCES = $(_libperf_headers)

--- a/src/gen-qtype.c.py
+++ b/src/gen-qtype.c.py
@@ -1,4 +1,20 @@
-/*
+#!/usr/bin/python3
+
+import csv
+from urllib.request import Request, urlopen
+from io import StringIO
+
+qtype = {}
+
+for row in csv.reader(StringIO(urlopen(Request('http://www.iana.org/assignments/dns-parameters/dns-parameters-4.csv')).read().decode('utf-8'))):
+    if row[0] == 'TYPE':
+        continue
+    try:
+        qtype[row[0]] = int(row[1])
+    except Exception:
+        continue
+
+print("""/*
  * Copyright 2019-2020 OARC, Inc.
  * Copyright 2017-2018 Akamai Technologies
  * Copyright 2006-2016 Nominum, Inc.
@@ -17,20 +33,14 @@
  * limitations under the License.
  */
 
-#ifndef PERF_RESULT_H
-#define PERF_RESULT_H 1
+#include "config.h"
 
-#include <assert.h>
+#include "qtype.h"
 
-typedef unsigned int perf_result_t;
+const perf_qtype_t qtype_table[] = {""")
 
-#define PERF_R_SUCCESS 0
-#define PERF_R_FAILURE 1
-#define PERF_R_CANCELED 2
-#define PERF_R_EOF 3
-#define PERF_R_INVALIDFILE 4
-#define PERF_R_NOMORE 5
-#define PERF_R_NOSPACE 6
-#define PERF_R_TIMEDOUT 7
+for k, v in qtype.items():
+    print("    { \"%s\", %d }," % (k, v))
 
-#endif
+print("""    { 0, 0 }
+};""")

--- a/src/os.c
+++ b/src/os.c
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#include "config.h"
+
 #include "os.h"
 
 #include "log.h"

--- a/src/qtype.c
+++ b/src/qtype.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2019-2020 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+
+#include "qtype.h"
+
+const perf_qtype_t qtype_table[] = {
+    { "A", 1 },
+    { "NS", 2 },
+    { "MD", 3 },
+    { "MF", 4 },
+    { "CNAME", 5 },
+    { "SOA", 6 },
+    { "MB", 7 },
+    { "MG", 8 },
+    { "MR", 9 },
+    { "NULL", 10 },
+    { "WKS", 11 },
+    { "PTR", 12 },
+    { "HINFO", 13 },
+    { "MINFO", 14 },
+    { "MX", 15 },
+    { "TXT", 16 },
+    { "RP", 17 },
+    { "AFSDB", 18 },
+    { "X25", 19 },
+    { "ISDN", 20 },
+    { "RT", 21 },
+    { "NSAP", 22 },
+    { "NSAP-PTR", 23 },
+    { "SIG", 24 },
+    { "KEY", 25 },
+    { "PX", 26 },
+    { "GPOS", 27 },
+    { "AAAA", 28 },
+    { "LOC", 29 },
+    { "NXT", 30 },
+    { "EID", 31 },
+    { "NIMLOC", 32 },
+    { "SRV", 33 },
+    { "ATMA", 34 },
+    { "NAPTR", 35 },
+    { "KX", 36 },
+    { "CERT", 37 },
+    { "A6", 38 },
+    { "DNAME", 39 },
+    { "SINK", 40 },
+    { "OPT", 41 },
+    { "APL", 42 },
+    { "DS", 43 },
+    { "SSHFP", 44 },
+    { "IPSECKEY", 45 },
+    { "RRSIG", 46 },
+    { "NSEC", 47 },
+    { "DNSKEY", 48 },
+    { "DHCID", 49 },
+    { "NSEC3", 50 },
+    { "NSEC3PARAM", 51 },
+    { "TLSA", 52 },
+    { "SMIMEA", 53 },
+    { "Unassigned", 54 },
+    { "HIP", 55 },
+    { "NINFO", 56 },
+    { "RKEY", 57 },
+    { "TALINK", 58 },
+    { "CDS", 59 },
+    { "CDNSKEY", 60 },
+    { "OPENPGPKEY", 61 },
+    { "CSYNC", 62 },
+    { "ZONEMD", 63 },
+    { "SVCB", 64 },
+    { "HTTPS", 65 },
+    { "SPF", 99 },
+    { "UINFO", 100 },
+    { "UID", 101 },
+    { "GID", 102 },
+    { "UNSPEC", 103 },
+    { "NID", 104 },
+    { "L32", 105 },
+    { "L64", 106 },
+    { "LP", 107 },
+    { "EUI48", 108 },
+    { "EUI64", 109 },
+    { "TKEY", 249 },
+    { "TSIG", 250 },
+    { "IXFR", 251 },
+    { "AXFR", 252 },
+    { "MAILB", 253 },
+    { "MAILA", 254 },
+    { "*", 255 },
+    { "URI", 256 },
+    { "CAA", 257 },
+    { "AVC", 258 },
+    { "DOA", 259 },
+    { "AMTRELAY", 260 },
+    { "TA", 32768 },
+    { "DLV", 32769 },
+    { "Reserved", 65535 },
+    { 0, 0 }
+};

--- a/src/qtype.h
+++ b/src/qtype.h
@@ -17,20 +17,16 @@
  * limitations under the License.
  */
 
-#ifndef PERF_RESULT_H
-#define PERF_RESULT_H 1
+#ifndef PERF_QTYPE_H
+#define PERF_QTYPE_H 1
 
-#include <assert.h>
+#include <stdint.h>
 
-typedef unsigned int perf_result_t;
+typedef struct perf_qtype {
+    char*    type;
+    uint16_t value;
+} perf_qtype_t;
 
-#define PERF_R_SUCCESS 0
-#define PERF_R_FAILURE 1
-#define PERF_R_CANCELED 2
-#define PERF_R_EOF 3
-#define PERF_R_INVALIDFILE 4
-#define PERF_R_NOMORE 5
-#define PERF_R_NOSPACE 6
-#define PERF_R_TIMEDOUT 7
+extern const perf_qtype_t qtype_table[];
 
 #endif


### PR DESCRIPTION
- Issue #73:
  - Re-implement `name_fromstring()`
  - Implement `qtype_fromstring()`
  - Add QTYPE table generator based on IANA DNS parameters CSV
  - Remove BIND as a dependency!
  - Rework `perf_result_t`
  - Remove BIND and BIND's dependencies from configure and packages
  - Update README