### PR TITLE
DOT, TLS version, Sonarcloud

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -60,8 +60,8 @@ AC_CHECK_LIB([m], [sqrt])
 # Check for OpenSSL
 PKG_CHECK_MODULES([libssl], [libssl])
 PKG_CHECK_MODULES([libcrypto], [libcrypto])
-AC_CHECK_LIB([ssl], [TLS_client_method],
-  [AC_DEFINE([HAVE_TLS_CLIENT_METHOD], [1], [Define to 1 if you have the 'TLS_client_method' function])])
+AC_CHECK_LIB([ssl], [TLS_method],
+  [AC_DEFINE([HAVE_TLS_METHOD], [1], [Define to 1 if you have the 'TLS_method' function])])
 
 # Check for LDNS
 PKG_CHECK_MODULES([libldns], [libldns >= 1.7.0], [AC_DEFINE([HAVE_LDNS], [1], [Define to 1 if you have the LDNS library])], [

--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -247,7 +247,7 @@ the file may be read fewer times.
 .br
 .RS
 Sets the port on which the DNS packets are sent. If not specified, the
-standard DNS port (udp/tcp 53, tls 853) is used.
+standard DNS port (udp/tcp 53, dot/tls 853) is used.
 .RE
 
 \fB-q \fInum_queries\fB\fR
@@ -267,7 +267,8 @@ Limits the number of requests per second. There is no default limit.
 \fB-m \fImode\fB\fR
 .br
 .RS
-Specifies the transport mode to use, "udp", "tcp" or "tls". Default is "udp".
+Specifies the transport mode to use, "udp", "tcp" or "dot"/"tls".
+Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -52,7 +52,7 @@
 #define DEFAULT_SERVER_NAME "127.0.0.1"
 #define DEFAULT_SERVER_PORT 53
 #define DEFAULT_SERVER_TLS_PORT 853
-#define DEFAULT_SERVER_PORTS "udp/tcp 53 or tls 853"
+#define DEFAULT_SERVER_PORTS "udp/tcp 53 or dot/tls 853"
 #define DEFAULT_LOCAL_PORT 0
 #define DEFAULT_MAX_OUTSTANDING 100
 #define DEFAULT_TIMEOUT 5
@@ -378,7 +378,7 @@ setup(int argc, char** argv, config_t* config)
     perf_opt_add('f', perf_opt_string, "family",
         "address family of DNS transport, inet or inet6", "any",
         &family);
-    perf_opt_add('m', perf_opt_string, "mode", "set transport mode: udp, tcp or tls", "udp", &mode);
+    perf_opt_add('m', perf_opt_string, "mode", "set transport mode: udp, tcp or dot/tls", "udp", &mode);
     perf_opt_add('s', perf_opt_string, "server_addr",
         "the server to query", DEFAULT_SERVER_NAME, &server_name);
     perf_opt_add('p', perf_opt_port, "port",

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -53,7 +53,7 @@
 #define DEFAULT_SERVER_NAME "127.0.0.1"
 #define DEFAULT_SERVER_PORT 53
 #define DEFAULT_SERVER_TLS_PORT 853
-#define DEFAULT_SERVER_PORTS "udp/tcp 53 or tls 853"
+#define DEFAULT_SERVER_PORTS "udp/tcp 53 or dot/tls 853"
 #define DEFAULT_LOCAL_PORT 0
 #define DEFAULT_SOCKET_BUFFER 32
 #define DEFAULT_TIMEOUT 45
@@ -236,7 +236,7 @@ setup(int argc, char** argv)
     perf_opt_add('f', perf_opt_string, "family",
         "address family of DNS transport, inet or inet6", "any",
         &family);
-    perf_opt_add('M', perf_opt_string, "mode", "set transport mode: udp, tcp or tls", "udp", &_mode);
+    perf_opt_add('M', perf_opt_string, "mode", "set transport mode: udp, tcp or dot/tls", "udp", &_mode);
     perf_opt_add('s', perf_opt_string, "server_addr",
         "the server to query", DEFAULT_SERVER_NAME, &server_name);
     perf_opt_add('p', perf_opt_port, "port",

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -17,6 +17,9 @@ grep -q "Queries sent: *2" test2.out
 ../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -m tls >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
+../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -m dot >test2.out
+cat test2.out
+grep -q "Queries sent: *2" test2.out
 
 ../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -e >test2.out
 cat test2.out


### PR DESCRIPTION
- Fix Sonarcloud issue:
  - `net`: Check for and use `TLS_method`
  - `net`: Only use TLS v1.2 and above versions
  - `opt`: Remove usage of `strcat()` and `strlcat()`
  - `opt`: Use safer `strncpy()`
- Use DoT alongside TLS
  - Add "dot" to `dnsperf -m` and `resperf -M` option
  - Update documentation