### PR TITLE
Checks, coverage, log, test IPv6

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -52,7 +52,8 @@ const char* perf_dns_rcode_strings[] = {
 
 perf_result_t perf_dname_fromstring(const char* str, size_t len, perf_buffer_t* target)
 {
-    size_t label_len;
+    size_t      label_len;
+    const char* orig_str = str;
 
     if (perf_buffer_availablelength(target) < len) {
         return PERF_R_NOSPACE;
@@ -66,6 +67,13 @@ perf_result_t perf_dname_fromstring(const char* str, size_t len, perf_buffer_t* 
         }
         if (!label_len) {
             // Just a dot
+            if (len > 1) {
+                // a dot but with labels after it
+                return PERF_R_FAILURE;
+            } else if (str != orig_str) {
+                // a dot but with labels before it
+                return PERF_R_FAILURE;
+            }
             perf_buffer_putuint8(target, 0);
             break;
         }

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -436,8 +436,14 @@ setup(int argc, char** argv, config_t* config)
     perf_opt_add('v', perf_opt_boolean, NULL,
         "verbose: report each query and additional information to stdout",
         NULL, &config->verbose);
+    bool log_stdout = false;
+    perf_opt_add('W', perf_opt_boolean, NULL, "log warnings and errors to stdout instead of stderr", NULL, &log_stdout);
 
     perf_opt_parse(argc, argv);
+
+    if (log_stdout) {
+        perf_log_tostdout();
+    }
 
     if (mode != 0)
         config->mode = perf_net_parsemode(mode);

--- a/src/log.c
+++ b/src/log.c
@@ -28,6 +28,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+static bool log_err_stdout = false;
+
 pthread_mutex_t log_lock = PTHREAD_MUTEX_INITIALIZER;
 
 static void
@@ -53,7 +55,7 @@ void perf_log_fatal(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    vlog(stderr, "Error", fmt, args);
+    vlog(log_err_stdout ? stdout : stderr, "Error", fmt, args);
     exit(1);
 }
 
@@ -61,5 +63,10 @@ void perf_log_warning(const char* fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    vlog(stderr, "Warning", fmt, args);
+    vlog(log_err_stdout ? stdout : stderr, "Warning", fmt, args);
+}
+
+void perf_log_tostdout(void)
+{
+    log_err_stdout = true;
 }

--- a/src/log.h
+++ b/src/log.h
@@ -23,5 +23,6 @@
 void perf_log_printf(const char* fmt, ...);
 void perf_log_fatal(const char* fmt, ...);
 void perf_log_warning(const char* fmt, ...);
+void perf_log_tostdout(void);
 
 #endif

--- a/src/net.c
+++ b/src/net.c
@@ -129,12 +129,6 @@ void perf_net_parseserver(int family, const char* name, unsigned int port, perf_
 {
     struct addrinfo* ai;
 
-    if (port == 0) {
-        fprintf(stderr, "server port cannot be 0\n");
-        perf_opt_usage();
-        exit(1);
-    }
-
     if (getaddrinfo(name, 0, 0, &ai) == 0) {
         struct addrinfo* a;
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -287,8 +287,14 @@ setup(int argc, char** argv)
     perf_opt_add('v', perf_opt_boolean, NULL,
         "verbose: report additional information to stdout",
         NULL, &verbose);
+    bool log_stdout = false;
+    perf_opt_add('W', perf_opt_boolean, NULL, "log warnings and errors to stdout instead of stderr", NULL, &log_stdout);
 
     perf_opt_parse(argc, argv);
+
+    if (log_stdout) {
+        perf_log_tostdout();
+    }
 
     if (_mode != 0)
         mode = perf_net_parsemode(_mode);

--- a/src/test/datafile3
+++ b/src/test/datafile3
@@ -1,0 +1,2 @@
+. A
+google.com. A

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -2,69 +2,77 @@
 
 test "$TEST_DNSPERF_WITH_NETWORK" = "1" || exit 0
 
-echo "google.com A" | ../dnsperf -vvv -s 1.1.1.1 -m udp >test2.out
+for ip in 1.1.1.1 2606:4700:4700::1111; do
+
+echo "google.com A" | ../dnsperf -vvv -s $ip -m udp >test2.out
 cat test2.out
 grep -q "Queries sent: *1" test2.out
-echo "google.com A" | ../dnsperf -vvv -s 1.1.1.1 -e -E 12345:0a0a0a0a -m udp >test2.out
+echo "google.com A" | ../dnsperf -vvv -s $ip -e -E 12345:0a0a0a0a -m udp >test2.out
 cat test2.out
 grep -q "Queries sent: *1" test2.out
-../dnsperf -vvv -s 1.1.1.1 -d "$srcdir/datafile" -n 2 -m udp >test2.out
+../dnsperf -vvv -s $ip -d "$srcdir/datafile" -n 2 -m udp >test2.out
 cat test2.out
 grep -q "Queries sent: *4" test2.out
-../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -m tcp >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m tcp >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
-../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -m tls >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m tls >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
-../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -m dot >test2.out
-cat test2.out
-grep -q "Queries sent: *2" test2.out
-
-../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -e >test2.out
-cat test2.out
-grep -q "Queries sent: *2" test2.out
-../dnsperf -s 1.1.1.1 -d "$srcdir/datafile" -n 1 -e -D >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m dot >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
 
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-md5:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-sha1:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-sha224:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-sha256:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-sha384:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-../dnsperf -d "$srcdir/updatefile" -u -s 1.1.1.1 -y hmac-sha512:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
-cat test2.out
-grep -q "Updates sent: *1" test2.out
-
-../resperf -s 1.1.1.1 -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp >test2.out
-cat test2.out
-grep -q "Queries sent: *2" test2.out
-../resperf -s 1.1.1.1 -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M tcp >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile3" -n 1 -m dot >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
 
-../resperf -s 1.1.1.1 -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp -D >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -e >test2.out
+cat test2.out
+grep -q "Queries sent: *2" test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -e -D >test2.out
+cat test2.out
+grep -q "Queries sent: *2" test2.out
+
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-md5:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-sha1:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-sha224:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-sha256:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-sha384:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+../dnsperf -d "$srcdir/updatefile" -u -s $ip -y hmac-sha512:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+cat test2.out
+grep -q "Updates sent: *1" test2.out
+
+../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp >test2.out
+cat test2.out
+grep -q "Queries sent: *2" test2.out
+../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M tcp >test2.out
+cat test2.out
+grep -q "Queries sent: *2" test2.out
+
+../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp -D >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
 # Disabled until https://github.com/DNS-OARC/dnsperf/issues/92 is fixed
-#../resperf -s 1.1.1.1 -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp -y hmac-sha256:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
+#../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M udp -y hmac-sha256:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= >test2.out
 #cat test2.out
 #grep -q "Queries sent: *2" test2.out
 
 # Ignore failure until https://github.com/DNS-OARC/dnsperf/issues/88 is fixed
 # May work on slower systems
-../resperf -s 1.1.1.1 -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M tls || true
+../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M tls || true
+
+done # for ip
 
 ../dnsperf -s 127.66.66.66 -d "$srcdir/datafile" -vvvv -m tcp -n 1 &
 sleep 2
@@ -82,3 +90,19 @@ pkill -KILL -u `id -u` dnsperf || true
 echo "invalid\ninvalid" | ../dnsperf -u -s 127.66.66.66 -m tcp &
 sleep 2
 pkill -KILL -u `id -u` dnsperf || true
+
+! echo "google.com A" \
+  | ../dnsperf -W -s 1.1.1.1 -y tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= \
+  | grep "adding TSIG: invalid owner name"
+echo ".google.com A" | ../dnsperf -W -s 1.1.1.1 \
+  | grep "invalid domain name"
+echo "google.com.. A" | ../dnsperf -W -s 1.1.1.1 \
+  | grep "invalid domain name"
+echo " A" | ../dnsperf -W -s 1.1.1.1 \
+  | grep "invalid query input format"
+echo "toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname" \
+  | ../dnsperf -W -s 1.1.1.1 -u \
+  | grep "Unable to parse domain name"
+echo -e "test\ndelete toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname" \
+  | ../dnsperf -W -s 1.1.1.1 -u \
+  | grep "invalid update command, domain name too large"

--- a/src/test/test3.sh
+++ b/src/test/test3.sh
@@ -24,18 +24,18 @@
 ! echo "" | ../dnsperf -y invalid:test:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8=
 ! echo "" | ../dnsperf -y test:invalid
 ! echo "" | ../dnsperf -y test
-! echo "" | ../dnsperf -y toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= \
+echo "" | ../dnsperf -W -y toooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooolongname:Ax42vsuHBjQOKlVHO8yU1zGuQ5hjeSz01LXiNze8pb8= \
   | grep "unable to setup TSIG, name too long"
-! echo "" | ../dnsperf -y test: | grep "unable to setup TSIG, secret empty"
+echo "" | ../dnsperf -W -y test: | grep "unable to setup TSIG, secret empty"
 
 ! ../dnsperf -e -E invalid
 ! ../dnsperf -e -E 9999999:invalid
 ! ../dnsperf -e -E 123:invalid
 ! ../dnsperf -e -E 123:fa0
-! ../dnsperf -E a: | grep "invalid EDNS Option, value is empty"
-! ../dnsperf -E a:a | grep "invalid EDNS Option, value must hex string (even number of characters)"
-! ../dnsperf -E a:aa | grep "invalid EDNS Option code 'a'"
-! ../dnsperf -E 1:xx | grep "invalid EDNS Option hex value 'xx'"
+../dnsperf -W -E a: | grep "invalid EDNS Option, value is empty"
+../dnsperf -W -E a:a | grep "invalid EDNS Option, value must hex string (even number of characters)"
+../dnsperf -W -E a:aa | grep "invalid EDNS Option code 'a'"
+../dnsperf -W -E 1:xx | grep "invalid EDNS Option hex value 'xx'"
 
 ! ../resperf -d does_not_exist
 ! ../resperf -r 0 -c 0


### PR DESCRIPTION
- `dns`: Add more check for parsing domain names to wire
- `log`: Add option `-W` for outputting warnings and errors to stdout
- Improve coverage and tests
- Run network tests using IPv6