### PR TITLE
Fix few python3 issues in queryparse

### DIFF
--- a/contrib/queryparse/queryparse
+++ b/contrib/queryparse/queryparse
@@ -121,7 +121,7 @@ def main(argv):
         outfile.close()
     sum = 0
     print("Statistics:")
-    qtypes = qtypecount.keys()
+    qtypes = list(qtypecount.keys())
     qtypes.sort()
     for qtype in qtypes:
         qtype_str = dns.rdatatype.to_text(qtype)

--- a/contrib/queryparse/queryparse
+++ b/contrib/queryparse/queryparse
@@ -73,7 +73,7 @@ def main(argv):
     while True:
         try:
             packet = pcap.next()
-        except: # lgtm [py/catch-base-exception]
+        except Exception:
             break
 
         if packet[0] is None:
@@ -101,7 +101,7 @@ def main(argv):
 
         try:
             msg = dns.message.from_wire(packet)
-        except: # lgtm [py/catch-base-exception]
+        except Exception:
             continue
         if not opts.recurse and not dns.flags.RD:
             continue


### PR DESCRIPTION
Queryparse now ends with error in python3. And cannot be interrupted, when it is parsing. Following commits fixes that.