### PR TITLE
datafile

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -124,6 +124,9 @@ static perf_result_t read_more(perf_datafile_t* dfile)
         memmove(dfile->databuf, &dfile->databuf[dfile->at], dfile->have - dfile->at);
         dfile->have -= dfile->at;
         dfile->at = 0;
+    } else if (dfile->at == dfile->have) {
+        dfile->have = 0;
+        dfile->at = 0;
     }
 
     n = read(dfile->fd, &dfile->databuf[dfile->have], sizeof(dfile->databuf) - dfile->have - 1);


### PR DESCRIPTION
- `datafile`: Fix a bug in `read_more()`, when used lines where perfectly aligned with the buffer it would exit (with "ran out of data") rather then read more