### PR TITLE
net

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,7 +30,7 @@ bin_PROGRAMS = dnsperf resperf
 dist_bin_SCRIPTS = resperf-report
 
 _libperf_sources = datafile.c dns.c log.c net.c opt.c os.c strerror.c qtype.c \
-  edns.c tsig.c
+  edns.c tsig.c net_udp.c net_tcp.c net_dot.c
 _libperf_headers = datafile.h dns.h log.h net.h opt.h os.h util.h strerror.h \
   list.h result.h buffer.h qtype.h edns.h tsig.h
 

--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -247,7 +247,7 @@ the file may be read fewer times.
 .br
 .RS
 Sets the port on which the DNS packets are sent. If not specified, the
-standard DNS port (udp/tcp 53, dot/tls 853) is used.
+standard DNS port (udp/tcp 53, DoT 853) is used.
 .RE
 
 \fB-q \fInum_queries\fB\fR
@@ -267,7 +267,7 @@ Limits the number of requests per second. There is no default limit.
 \fB-m \fImode\fB\fR
 .br
 .RS
-Specifies the transport mode to use, "udp", "tcp" or "dot"/"tls".
+Specifies the transport mode to use, "udp", "tcp" or "dot".
 Default is "udp".
 .RE
 

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -51,8 +51,8 @@
 
 #define DEFAULT_SERVER_NAME "127.0.0.1"
 #define DEFAULT_SERVER_PORT 53
-#define DEFAULT_SERVER_TLS_PORT 853
-#define DEFAULT_SERVER_PORTS "udp/tcp 53 or dot/tls 853"
+#define DEFAULT_SERVER_DOT_PORT 853
+#define DEFAULT_SERVER_PORTS "udp/tcp 53 or DoT 853"
 #define DEFAULT_LOCAL_PORT 0
 #define DEFAULT_MAX_OUTSTANDING 100
 #define DEFAULT_TIMEOUT 5
@@ -140,9 +140,9 @@ typedef struct {
     pthread_mutex_t lock;
     pthread_cond_t  cond;
 
-    unsigned int            nsocks;
-    int                     current_sock;
-    struct perf_net_socket* socks;
+    unsigned int             nsocks;
+    int                      current_sock;
+    struct perf_net_socket** socks;
 
     bool     done_sending;
     uint64_t done_send_time;
@@ -194,8 +194,13 @@ print_initial_status(const config_t* config)
     printf("\n");
 
     perf_sockaddr_format(&config->server_addr, buf, sizeof(buf));
-    printf("[Status] Sending %s (to %s)\n",
-        config->updates ? "updates" : "queries", buf);
+    if (perf_sockaddr_isinet6(&config->server_addr)) {
+        printf("[Status] Sending %s (to [%s]:%d)\n",
+            config->updates ? "updates" : "queries", buf, perf_sockaddr_port(&config->server_addr));
+    } else {
+        printf("[Status] Sending %s (to %s:%d)\n",
+            config->updates ? "updates" : "queries", buf, perf_sockaddr_port(&config->server_addr));
+    }
 
     now = time(NULL);
     printf("[Status] Started at: %s", ctime_r(&now, ct));
@@ -378,7 +383,7 @@ setup(int argc, char** argv, config_t* config)
     perf_opt_add('f', perf_opt_string, "family",
         "address family of DNS transport, inet or inet6", "any",
         &family);
-    perf_opt_add('m', perf_opt_string, "mode", "set transport mode: udp, tcp or dot/tls", "udp", &mode);
+    perf_opt_add('m', perf_opt_string, "mode", "set transport mode: udp, tcp or dot", "udp", &mode);
     perf_opt_add('s', perf_opt_string, "server_addr",
         "the server to query", DEFAULT_SERVER_NAME, &server_name);
     perf_opt_add('p', perf_opt_port, "port",
@@ -449,7 +454,7 @@ setup(int argc, char** argv, config_t* config)
         config->mode = perf_net_parsemode(mode);
 
     if (!server_port) {
-        server_port = config->mode == sock_tls ? DEFAULT_SERVER_TLS_PORT : DEFAULT_SERVER_PORT;
+        server_port = config->mode == sock_dot ? DEFAULT_SERVER_DOT_PORT : DEFAULT_SERVER_PORT;
     }
 
     if (family != NULL)
@@ -620,7 +625,7 @@ do_send(void* arg)
 
         i = tinfo->nsocks * 2;
         while (i--) {
-            q->sock = &tinfo->socks[tinfo->current_sock++ % tinfo->nsocks];
+            q->sock = tinfo->socks[tinfo->current_sock++ % tinfo->nsocks];
             switch (perf_net_sockready(q->sock, threadpipe[0], TIMEOUT_CHECK_TIME)) {
             case 0:
                 if (config->verbose) {
@@ -719,7 +724,7 @@ do_send(void* arg)
     while (any_inprogress) {
         any_inprogress = 0;
         for (i = 0; i < tinfo->nsocks; i++) {
-            if (perf_net_sockready(&tinfo->socks[i], threadpipe[0], TIMEOUT_CHECK_TIME) == -1 && errno == EINPROGRESS) {
+            if (perf_net_sockready(tinfo->socks[i], threadpipe[0], TIMEOUT_CHECK_TIME) == -1 && errno == EINPROGRESS) {
                 any_inprogress = 1;
             }
         }
@@ -788,7 +793,7 @@ recv_one(threadinfo_t* tinfo, int which_sock,
 
     packet_header = (uint16_t*)packet_buffer;
 
-    n   = perf_net_recv(&tinfo->socks[which_sock], packet_buffer, packet_size, 0);
+    n   = perf_net_recv(tinfo->socks[which_sock], packet_buffer, packet_size, 0);
     now = perf_get_time();
     if (n < 0) {
         *saved_errnop = errno;
@@ -799,7 +804,7 @@ recv_one(threadinfo_t* tinfo, int which_sock,
         *saved_errnop = EAGAIN;
         return false;
     }
-    recvd->sock           = &tinfo->socks[which_sock];
+    recvd->sock           = tinfo->socks[which_sock];
     recvd->qid            = ntohs(packet_header[0]);
     recvd->rcode          = ntohs(packet_header[1]) & 0xF;
     recvd->size           = n;
@@ -1091,11 +1096,15 @@ threadinfo_init(threadinfo_t* tinfo, const config_t* config,
     socket_offset = 0;
     for (i = 0; i < offset; i++)
         socket_offset += threads[i].nsocks;
-    for (i = 0; i < tinfo->nsocks; i++)
+    for (i = 0; i < tinfo->nsocks; i++) {
         tinfo->socks[i] = perf_net_opensocket(config->mode, &config->server_addr,
             &config->local_addr,
             socket_offset++,
             config->bufsize);
+        if (!tinfo->socks[i]) {
+            perf_log_fatal("perf_net_opensocket(): no socket returned, out of memory?");
+        }
+    }
     tinfo->current_sock = 0;
 
     PERF_THREAD(&tinfo->receiver, do_recv, tinfo);
@@ -1118,7 +1127,7 @@ threadinfo_cleanup(threadinfo_t* tinfo, times_t* times)
     if (interrupted)
         cancel_queries(tinfo);
     for (i = 0; i < tinfo->nsocks; i++)
-        perf_net_close(&tinfo->socks[i]);
+        perf_net_close(tinfo->socks[i]);
     if (tinfo->last_recv > times->end_time)
         times->end_time = tinfo->last_recv;
 }
@@ -1152,8 +1161,8 @@ int main(int argc, char** argv)
     perf_os_blocksignal(SIGINT, true);
     switch (config.mode) {
     case sock_tcp:
-    case sock_tls:
-        // block SIGPIPE for TCP/TLS mode, if connection is closed it will generate a signal
+    case sock_dot:
+        // block SIGPIPE for TCP/DOT mode, if connection is closed it will generate a signal
         perf_os_blocksignal(SIGPIPE, true);
         break;
     default:

--- a/src/net.c
+++ b/src/net.c
@@ -23,25 +23,28 @@
 
 #include "log.h"
 #include "opt.h"
-#include "os.h"
-#include "strerror.h"
 
 #include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <errno.h>
 #include <poll.h>
-#include <openssl/err.h>
 #include <netdb.h>
 #include <arpa/inet.h>
 
-#define TCP_RECV_BUF_SIZE (16 * 1024)
-#define TCP_SEND_BUF_SIZE (4 * 1024)
+enum perf_net_mode perf_net_parsemode(const char* mode)
+{
+    if (!strcmp(mode, "udp")) {
+        return sock_udp;
+    } else if (!strcmp(mode, "tcp")) {
+        return sock_tcp;
+    } else if (!strcmp(mode, "tls") || !strcmp(mode, "dot")) {
+        return sock_dot;
+    }
 
-static SSL_CTX* ssl_ctx = 0;
+    perf_log_warning("invalid socket mode");
+    perf_opt_usage();
+    exit(1);
+}
 
 int perf_net_parsefamily(const char* family)
 {
@@ -49,10 +52,8 @@ int perf_net_parsefamily(const char* family)
         return AF_UNSPEC;
     else if (strcmp(family, "inet") == 0)
         return AF_INET;
-#ifdef AF_INET6
     else if (strcmp(family, "inet6") == 0)
         return AF_INET6;
-#endif
     else {
         fprintf(stderr, "invalid family %s\n", family);
         perf_opt_usage();
@@ -82,9 +83,9 @@ in_port_t perf_sockaddr_port(const perf_sockaddr_t* sockaddr)
 {
     switch (sockaddr->sa.sa.sa_family) {
     case AF_INET:
-        return sockaddr->sa.sin.sin_port;
+        return ntohs(sockaddr->sa.sin.sin_port);
     case AF_INET6:
-        return sockaddr->sa.sin6.sin6_port;
+        return ntohs(sockaddr->sa.sin6.sin6_port);
     default:
         break;
     }
@@ -95,10 +96,10 @@ void perf_sockaddr_setport(perf_sockaddr_t* sockaddr, in_port_t port)
 {
     switch (sockaddr->sa.sa.sa_family) {
     case AF_INET:
-        sockaddr->sa.sin.sin_port = port;
+        sockaddr->sa.sin.sin_port = htons(port);
         break;
     case AF_INET6:
-        sockaddr->sa.sin6.sin6_port = port;
+        sockaddr->sa.sin6.sin6_port = htons(port);
         break;
     default:
         break;
@@ -188,75 +189,14 @@ void perf_net_parselocal(int family, const char* name, unsigned int port,
     exit(1);
 }
 
-struct perf_net_socket perf_net_opensocket(enum perf_net_mode mode, const perf_sockaddr_t* server, const perf_sockaddr_t* local, unsigned int offset, int bufsize)
+struct perf_net_socket* perf_net_opensocket(enum perf_net_mode mode, const perf_sockaddr_t* server, const perf_sockaddr_t* local, unsigned int offset, size_t bufsize)
 {
-    int                    family;
-    perf_sockaddr_t        tmp;
-    int                    port;
-    int                    ret;
-    int                    flags;
-    struct perf_net_socket sock = { .mode = mode, .is_ready = 1 };
+    int             port;
+    perf_sockaddr_t tmp;
 
-    family = server->sa.sa.sa_family;
-
-    if (local->sa.sa.sa_family != family) {
+    if (server->sa.sa.sa_family != local->sa.sa.sa_family) {
         perf_log_fatal("server and local addresses have different families");
     }
-
-    switch (mode) {
-    case sock_udp:
-        sock.fd = socket(family, SOCK_DGRAM, 0);
-        break;
-    case sock_tls:
-        if (pthread_mutex_init(&sock.lock, 0)) {
-            perf_log_fatal("pthread_mutex_init() failed");
-        }
-        if ((sock.fd = socket(family, SOCK_STREAM, 0)) < 0) {
-            char __s[256];
-            perf_log_fatal("socket: %s", perf_strerror_r(errno, __s, sizeof(__s)));
-        }
-        if (!ssl_ctx) {
-#ifdef HAVE_TLS_METHOD
-            if (!(ssl_ctx = SSL_CTX_new(TLS_method()))) {
-                perf_log_fatal("SSL_CTX_new(): %s", ERR_error_string(ERR_get_error(), 0));
-            }
-            if (!SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_2_VERSION)) {
-                perf_log_fatal("SSL_CTX_set_min_proto_version(TLS1_2_VERSION): %s", ERR_error_string(ERR_get_error(), 0));
-            }
-#else
-            if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method()))) {
-                perf_log_fatal("SSL_CTX_new(): %s", ERR_error_string(ERR_get_error(), 0));
-            }
-#endif
-        }
-        if (!(sock.ssl = SSL_new(ssl_ctx))) {
-            perf_log_fatal("SSL_new(): %s", ERR_error_string(ERR_get_error(), 0));
-        }
-        if (!(ret = SSL_set_fd(sock.ssl, sock.fd))) {
-            perf_log_fatal("SSL_set_fd(): %s", ERR_error_string(SSL_get_error(sock.ssl, ret), 0));
-        }
-        break;
-    case sock_tcp:
-        sock.fd = socket(family, SOCK_STREAM, 0);
-        break;
-    default:
-        perf_log_fatal("perf_net_opensocket(): invalid mode");
-    }
-
-    if (sock.fd == -1) {
-        char __s[256];
-        perf_log_fatal("socket: %s", perf_strerror_r(errno, __s, sizeof(__s)));
-    }
-
-#if defined(AF_INET6) && defined(IPV6_V6ONLY)
-    if (family == AF_INET6) {
-        int on = 1;
-
-        if (setsockopt(sock.fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) == -1) {
-            perf_log_warning("setsockopt(IPV6_V6ONLY) failed");
-        }
-    }
-#endif
 
     tmp  = *local;
     port = perf_sockaddr_port(&tmp);
@@ -267,398 +207,16 @@ struct perf_net_socket perf_net_opensocket(enum perf_net_mode mode, const perf_s
         perf_sockaddr_setport(&tmp, port);
     }
 
-    if (bind(sock.fd, &tmp.sa.sa, tmp.length) == -1) {
-        char __s[256];
-        perf_log_fatal("bind: %s", perf_strerror_r(errno, __s, sizeof(__s)));
-    }
-
-    if (bufsize > 0) {
-        bufsize *= 1024;
-
-        ret = setsockopt(sock.fd, SOL_SOCKET, SO_RCVBUF,
-            &bufsize, sizeof(bufsize));
-        if (ret < 0)
-            perf_log_warning("setsockbuf(SO_RCVBUF) failed");
-
-        ret = setsockopt(sock.fd, SOL_SOCKET, SO_SNDBUF,
-            &bufsize, sizeof(bufsize));
-        if (ret < 0)
-            perf_log_warning("setsockbuf(SO_SNDBUF) failed");
-    }
-
-    flags = fcntl(sock.fd, F_GETFL, 0);
-    if (flags < 0)
-        perf_log_fatal("fcntl(F_GETFL)");
-    ret = fcntl(sock.fd, F_SETFL, flags | O_NONBLOCK);
-    if (ret < 0)
-        perf_log_fatal("fcntl(F_SETFL)");
-
-    if (mode == sock_tcp || mode == sock_tls) {
-        if (connect(sock.fd, &server->sa.sa, server->length)) {
-            if (errno == EINPROGRESS) {
-                sock.is_ready = 0;
-            } else {
-                char __s[256];
-                perf_log_fatal("connect() failed: %s", perf_strerror_r(errno, __s, sizeof(__s)));
-            }
-        }
-        sock.recvbuf   = malloc(TCP_RECV_BUF_SIZE);
-        sock.at        = 0;
-        sock.have_more = 0;
-        sock.sendbuf   = malloc(TCP_SEND_BUF_SIZE);
-        if (!sock.recvbuf || !sock.sendbuf) {
-            perf_log_fatal("perf_net_opensocket() failed: unable to allocate buffers");
-        }
-    }
-
-    return sock;
-}
-
-ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags)
-{
-    switch (sock->mode) {
-    case sock_tls: {
-        ssize_t  n;
-        uint16_t dnslen, dnslen2;
-
-        if (!sock->have_more) {
-            if (pthread_mutex_lock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_lock() failed");
-            }
-            if (!sock->is_ready) {
-                if (pthread_mutex_unlock(&sock->lock)) {
-                    perf_log_fatal("pthread_mutex_unlock() failed");
-                }
-                errno = EAGAIN;
-                return -1;
-            }
-
-            n = SSL_read(sock->ssl, sock->recvbuf + sock->at, TCP_RECV_BUF_SIZE - sock->at);
-            if (n < 0) {
-                int err = SSL_get_error(sock->ssl, n);
-                if (pthread_mutex_unlock(&sock->lock)) {
-                    perf_log_fatal("pthread_mutex_unlock() failed");
-                }
-                if (err == SSL_ERROR_WANT_READ) {
-                    errno = EAGAIN;
-                } else {
-                    errno = EBADF;
-                }
-                return -1;
-            }
-            if (pthread_mutex_unlock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_unlock() failed");
-            }
-
-            sock->at += n;
-            if (sock->at < 3) {
-                errno = EAGAIN;
-                return -1;
-            }
-        }
-
-        memcpy(&dnslen, sock->recvbuf, 2);
-        dnslen = ntohs(dnslen);
-        if (sock->at < dnslen + 2) {
-            errno = EAGAIN;
-            return -1;
-        }
-        memcpy(buf, sock->recvbuf + 2, len < dnslen ? len : dnslen);
-        memmove(sock->recvbuf, sock->recvbuf + 2 + dnslen, sock->at - 2 - dnslen);
-        sock->at -= 2 + dnslen;
-
-        if (sock->at > 2) {
-            memcpy(&dnslen2, sock->recvbuf, 2);
-            dnslen2 = ntohs(dnslen2);
-            if (sock->at >= dnslen2 + 2) {
-                sock->have_more = 1;
-                return dnslen;
-            }
-        }
-
-        sock->have_more = 0;
-        return dnslen;
-    }
-    case sock_tcp: {
-        ssize_t  n;
-        uint16_t dnslen, dnslen2;
-
-        if (!sock->have_more) {
-            n = recv(sock->fd, sock->recvbuf + sock->at, TCP_RECV_BUF_SIZE - sock->at, flags);
-            if (n < 0) {
-                if (errno == ECONNRESET) {
-                    // Treat connection reset like try again until reconnection features are in
-                    errno = EAGAIN;
-                }
-                return n;
-            }
-            sock->at += n;
-            if (sock->at < 3) {
-                errno = EAGAIN;
-                return -1;
-            }
-        }
-
-        memcpy(&dnslen, sock->recvbuf, 2);
-        dnslen = ntohs(dnslen);
-        if (sock->at < dnslen + 2) {
-            errno = EAGAIN;
-            return -1;
-        }
-        memcpy(buf, sock->recvbuf + 2, len < dnslen ? len : dnslen);
-        memmove(sock->recvbuf, sock->recvbuf + 2 + dnslen, sock->at - 2 - dnslen);
-        sock->at -= 2 + dnslen;
-
-        if (sock->at > 2) {
-            memcpy(&dnslen2, sock->recvbuf, 2);
-            dnslen2 = ntohs(dnslen2);
-            if (sock->at >= dnslen2 + 2) {
-                sock->have_more = 1;
-                return dnslen;
-            }
-        }
-
-        sock->have_more = 0;
-        return dnslen;
-    }
-    default:
-        break;
-    }
-
-    return recv(sock->fd, buf, len, flags);
-}
-
-ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags,
-    const struct sockaddr* dest_addr, socklen_t addrlen)
-{
-    switch (sock->mode) {
-    case sock_tls: {
-        size_t send = len < TCP_SEND_BUF_SIZE - 2 ? len : (TCP_SEND_BUF_SIZE - 2);
-        // TODO: We only send what we can send, because we can't continue sending
-        uint16_t dnslen = htons(send);
-        ssize_t  n;
-
-        memcpy(sock->sendbuf, &dnslen, 2);
-        memcpy(sock->sendbuf + 2, buf, send);
-        if (pthread_mutex_lock(&sock->lock)) {
-            perf_log_fatal("pthread_mutex_lock() failed");
-        }
-        n = SSL_write(sock->ssl, sock->sendbuf, send + 2);
-        if (n < 0) {
-            perf_log_warning("SSL_write(): %s", ERR_error_string(SSL_get_error(sock->ssl, n), 0));
-            errno = EBADF;
-        }
-        if (pthread_mutex_unlock(&sock->lock)) {
-            perf_log_fatal("pthread_mutex_unlock() failed");
-        }
-
-        if (n > 0 && n < send + 2) {
-            sock->sending = n;
-            sock->flags   = flags;
-            memcpy(&sock->dest_addr, dest_addr, addrlen);
-            sock->addrlen  = addrlen;
-            sock->is_ready = 0;
-            errno          = EINPROGRESS;
-            return -1;
-        }
-
-        return n > 0 ? n - 2 : n;
-    }
-    case sock_tcp: {
-        size_t send = len < TCP_SEND_BUF_SIZE - 2 ? len : (TCP_SEND_BUF_SIZE - 2);
-        // TODO: We only send what we can send, because we can't continue sending
-        uint16_t dnslen = htons(send);
-        ssize_t  n;
-
-        memcpy(sock->sendbuf, &dnslen, 2);
-        memcpy(sock->sendbuf + 2, buf, send);
-        n = sendto(sock->fd, sock->sendbuf, send + 2, flags, dest_addr, addrlen);
-
-        if (n > 0 && n < send + 2) {
-            sock->sending = n;
-            sock->flags   = flags;
-            memcpy(&sock->dest_addr, dest_addr, addrlen);
-            sock->addrlen  = addrlen;
-            sock->is_ready = 0;
-            errno          = EINPROGRESS;
-            return -1;
-        }
-
-        return n > 0 ? n - 2 : n;
-    }
-    default:
-        break;
-    }
-    return sendto(sock->fd, buf, len, flags, dest_addr, addrlen);
-}
-
-int perf_net_close(struct perf_net_socket* sock)
-{
-    return close(sock->fd);
-}
-
-int perf_net_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b)
-{
-    return sock_a->fd == sock_b->fd;
-}
-
-enum perf_net_mode perf_net_parsemode(const char* mode)
-{
-    if (!strcmp(mode, "udp")) {
-        return sock_udp;
-    } else if (!strcmp(mode, "tcp")) {
-        return sock_tcp;
-    } else if (!strcmp(mode, "tls") || !strcmp(mode, "dot")) {
-        return sock_tls;
-    }
-
-    perf_log_warning("invalid socket mode");
-    perf_opt_usage();
-    exit(1);
-}
-
-int perf_net_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
-{
-    if (sock->is_ready) {
-        return 1;
-    }
-
-    switch (sock->mode) {
-    case sock_tls: {
-        int ret;
-
-        if (sock->sending) {
-            uint16_t dnslen;
-            ssize_t  n;
-
-            memcpy(&dnslen, sock->sendbuf, 2);
-            dnslen = ntohs(dnslen);
-            if (pthread_mutex_lock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_lock() failed");
-            }
-            n = SSL_write(sock->ssl, sock->sendbuf + sock->sending, dnslen + 2 - sock->sending);
-            if (n < 1) {
-                if (n < 0) {
-                    perf_log_warning("SSL_write(): %s", ERR_error_string(SSL_get_error(sock->ssl, n), 0));
-                    errno = EBADF;
-                }
-                if (pthread_mutex_unlock(&sock->lock)) {
-                    perf_log_fatal("pthread_mutex_unlock() failed");
-                }
-                return -1;
-            }
-            if (pthread_mutex_unlock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_unlock() failed");
-            }
-            sock->sending += n;
-            if (sock->sending < dnslen + 2) {
-                errno = EINPROGRESS;
-                return -1;
-            }
-            sock->sending  = 0;
-            sock->is_ready = 1;
-            return 1;
-        }
-
-        if (!sock->is_ssl_ready) {
-            switch (perf_os_waituntilanywritable(sock, 1, pipe_fd, timeout)) {
-            case PERF_R_TIMEDOUT:
-                return -1;
-            case PERF_R_SUCCESS: {
-                int       error = 0;
-                socklen_t len   = (socklen_t)sizeof(error);
-
-                getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, (void*)&error, &len);
-                if (error != 0) {
-                    if (error == EINPROGRESS
-#if EWOULDBLOCK != EAGAIN
-                        || error == EWOULDBLOCK
-#endif
-                        || error == EAGAIN) {
-                        return 0;
-                    }
-                    return -1;
-                }
-            }
-            }
-            sock->is_ssl_ready = 1;
-        }
-
-        if (pthread_mutex_lock(&sock->lock)) {
-            perf_log_fatal("pthread_mutex_lock() failed");
-        }
-        ret = SSL_connect(sock->ssl);
-        if (!ret) {
-            perf_log_warning("SSL_connect(): %s", ERR_error_string(SSL_get_error(sock->ssl, ret), 0));
-            if (pthread_mutex_unlock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_unlock() failed");
-            }
-            return -1;
-        }
-        if (ret < 0) {
-            int err = SSL_get_error(sock->ssl, ret);
-            if (pthread_mutex_unlock(&sock->lock)) {
-                perf_log_fatal("pthread_mutex_unlock() failed");
-            }
-            if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
-                return 0;
-            }
-            perf_log_warning("SSL_connect(): %s", ERR_error_string(err, 0));
-            return -1;
-        }
-        sock->is_ready = 1;
-        if (pthread_mutex_unlock(&sock->lock)) {
-            perf_log_fatal("pthread_mutex_unlock() failed");
-        }
-        return 1;
-    }
+    switch (mode) {
+    case sock_udp:
+        return perf_net_udp_opensocket(server, &tmp, bufsize);
     case sock_tcp:
-        if (sock->sending) {
-            uint16_t dnslen;
-            ssize_t  n;
-
-            memcpy(&dnslen, sock->sendbuf, 2);
-            dnslen = ntohs(dnslen);
-            n      = sendto(sock->fd, sock->sendbuf + sock->sending, dnslen + 2 - sock->sending, sock->flags, (struct sockaddr*)&sock->dest_addr, sock->addrlen);
-            if (n < 1) {
-                return -1;
-            }
-            sock->sending += n;
-            if (sock->sending < dnslen + 2) {
-                errno = EINPROGRESS;
-                return -1;
-            }
-            sock->sending  = 0;
-            sock->is_ready = 1;
-            return 1;
-        }
-
-        switch (perf_os_waituntilanywritable(sock, 1, pipe_fd, timeout)) {
-        case PERF_R_TIMEDOUT:
-            return -1;
-        case PERF_R_SUCCESS: {
-            int       error = 0;
-            socklen_t len   = (socklen_t)sizeof(error);
-
-            getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, (void*)&error, &len);
-            if (error != 0) {
-                if (error == EINPROGRESS
-#if EWOULDBLOCK != EAGAIN
-                    || error == EWOULDBLOCK
-#endif
-                    || error == EAGAIN) {
-                    return 0;
-                }
-                return -1;
-            }
-            sock->is_ready = 1;
-            return 1;
-        }
-        }
-        break;
+        return perf_net_tcp_opensocket(server, &tmp, bufsize);
+    case sock_dot:
+        return perf_net_dot_opensocket(server, &tmp, bufsize);
     default:
-        break;
+        perf_log_fatal("perf_net_opensocket(): invalid mode");
     }
 
-    return -1;
+    return 0;
 }

--- a/src/net.h
+++ b/src/net.h
@@ -25,6 +25,11 @@
 #include <openssl/ssl.h>
 #include <pthread.h>
 #include <netinet/in.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#define TCP_RECV_BUF_SIZE (16 * 1024)
+#define TCP_SEND_BUF_SIZE (4 * 1024)
 
 struct perf_sockaddr {
     union {
@@ -42,20 +47,64 @@ enum perf_net_mode {
     sock_pipe,
     sock_udp,
     sock_tcp,
-    sock_tls
+    sock_dot
 };
 
+struct perf_net_socket;
+
+typedef ssize_t (*perf_net_recv_t)(struct perf_net_socket* sock, void* buf, size_t len, int flags);
+typedef ssize_t (*perf_net_sendto_t)(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+typedef int (*perf_net_close_t)(struct perf_net_socket* sock);
+typedef int (*perf_net_sockeq_t)(struct perf_net_socket* sock, struct perf_net_socket* other);
+typedef int (*perf_net_sockready_t)(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
+
 struct perf_net_socket {
-    enum perf_net_mode      mode;
-    int                     fd, have_more, is_ready, flags, is_ssl_ready;
-    char*                   recvbuf;
-    size_t                  at, sending;
-    char*                   sendbuf;
-    struct sockaddr_storage dest_addr;
-    socklen_t               addrlen;
-    SSL*                    ssl;
-    pthread_mutex_t         lock;
+    enum perf_net_mode   mode;
+    perf_net_recv_t      recv;
+    perf_net_sendto_t    sendto;
+    perf_net_close_t     close;
+    perf_net_sockeq_t    sockeq;
+    perf_net_sockready_t sockready;
+
+    int  fd;
+    bool is_sending; // indicate that the socket is still sending from buffers
+    bool have_more; // indicate that the socket has more bytes to process in its recieve buffers
 };
+
+static inline ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags)
+{
+    return sock->recv(sock, buf, len, flags);
+}
+
+static inline ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return sock->sendto(sock, buf, len, flags, dest_addr, addrlen);
+}
+
+static inline int perf_net_close(struct perf_net_socket* sock)
+{
+    return sock->close(sock);
+}
+
+static inline int perf_net_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b)
+{
+    assert(sock_a);
+    assert(sock_b);
+    assert(sock_a->mode == sock_b->mode);
+    return sock_a->sockeq(sock_a, sock_b);
+}
+
+static inline int perf_net_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
+{
+    return sock->sockready(sock, pipe_fd, timeout);
+}
+
+enum perf_net_mode perf_net_parsemode(const char* mode);
+
+int perf_net_parsefamily(const char* family);
+
+void perf_net_parseserver(int family, const char* name, unsigned int port, perf_sockaddr_t* addr);
+void perf_net_parselocal(int family, const char* name, unsigned int port, perf_sockaddr_t* addr);
 
 void      perf_sockaddr_fromin(perf_sockaddr_t* sockaddr, const struct in_addr* in, in_port_t port);
 void      perf_sockaddr_fromin6(perf_sockaddr_t* sockaddr, const struct in6_addr* in, in_port_t port);
@@ -63,22 +112,15 @@ in_port_t perf_sockaddr_port(const perf_sockaddr_t* sockaddr);
 void      perf_sockaddr_setport(perf_sockaddr_t* sockaddr, in_port_t port);
 void      perf_sockaddr_format(const perf_sockaddr_t* sockaddr, char* buf, size_t len);
 
-ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags);
-ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags,
-    const struct sockaddr* dest_addr, socklen_t addrlen);
+static inline int perf_sockaddr_isinet6(const perf_sockaddr_t* sockaddr)
+{
+    return sockaddr->sa.sa.sa_family == AF_INET6;
+}
 
-int perf_net_close(struct perf_net_socket* sock);
-int perf_net_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b);
+struct perf_net_socket* perf_net_opensocket(enum perf_net_mode mode, const perf_sockaddr_t* server, const perf_sockaddr_t* local, unsigned int offset, size_t bufsize);
 
-int perf_net_parsefamily(const char* family);
-
-void perf_net_parseserver(int family, const char* name, unsigned int port, perf_sockaddr_t* addr);
-void perf_net_parselocal(int family, const char* name, unsigned int port, perf_sockaddr_t* addr);
-
-struct perf_net_socket perf_net_opensocket(enum perf_net_mode mode, const perf_sockaddr_t* server, const perf_sockaddr_t* local, unsigned int offset, int bufsize);
-
-enum perf_net_mode perf_net_parsemode(const char* mode);
-
-int perf_net_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
+struct perf_net_socket* perf_net_udp_opensocket(const perf_sockaddr_t*, const perf_sockaddr_t*, size_t);
+struct perf_net_socket* perf_net_tcp_opensocket(const perf_sockaddr_t*, const perf_sockaddr_t*, size_t);
+struct perf_net_socket* perf_net_dot_opensocket(const perf_sockaddr_t*, const perf_sockaddr_t*, size_t);
 
 #endif

--- a/src/net_dot.c
+++ b/src/net_dot.c
@@ -1,0 +1,322 @@
+/*
+ * Copyright 2019-2021 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+
+#include "net.h"
+
+#include "log.h"
+#include "strerror.h"
+#include "util.h"
+#include "os.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <openssl/err.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+static SSL_CTX* ssl_ctx = 0;
+
+#define self ((struct perf__dot_socket*)sock)
+
+struct perf__dot_socket {
+    struct perf_net_socket base;
+
+    pthread_mutex_t lock;
+    SSL*            ssl;
+
+    char   recvbuf[TCP_RECV_BUF_SIZE], sendbuf[TCP_SEND_BUF_SIZE];
+    size_t at, sending;
+    bool   is_ready, is_conn_ready;
+};
+
+static ssize_t perf__dot_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags)
+{
+    ssize_t  n;
+    uint16_t dnslen, dnslen2;
+
+    if (!sock->have_more) {
+        PERF_LOCK(&self->lock);
+        if (!self->is_ready) {
+            PERF_UNLOCK(&self->lock);
+            errno = EAGAIN;
+            return -1;
+        }
+
+        n = SSL_read(self->ssl, self->recvbuf + self->at, TCP_RECV_BUF_SIZE - self->at);
+        if (n < 0) {
+            int err = SSL_get_error(self->ssl, n);
+            PERF_UNLOCK(&self->lock);
+            if (err == SSL_ERROR_WANT_READ) {
+                errno = EAGAIN;
+            } else {
+                errno = EBADF;
+            }
+            return -1;
+        }
+        PERF_UNLOCK(&self->lock);
+
+        self->at += n;
+        if (self->at < 3) {
+            errno = EAGAIN;
+            return -1;
+        }
+    }
+
+    memcpy(&dnslen, self->recvbuf, 2);
+    dnslen = ntohs(dnslen);
+    if (self->at < dnslen + 2) {
+        errno = EAGAIN;
+        return -1;
+    }
+    memcpy(buf, self->recvbuf + 2, len < dnslen ? len : dnslen);
+    memmove(self->recvbuf, self->recvbuf + 2 + dnslen, self->at - 2 - dnslen);
+    self->at -= 2 + dnslen;
+
+    if (self->at > 2) {
+        memcpy(&dnslen2, self->recvbuf, 2);
+        dnslen2 = ntohs(dnslen2);
+        if (self->at >= dnslen2 + 2) {
+            sock->have_more = true;
+            return dnslen;
+        }
+    }
+
+    sock->have_more = false;
+    return dnslen;
+}
+
+static ssize_t perf__dot_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    size_t send = len < TCP_SEND_BUF_SIZE - 2 ? len : (TCP_SEND_BUF_SIZE - 2);
+    // TODO: We only send what we can send, because we can't continue sending
+    uint16_t dnslen = htons(send);
+    ssize_t  n;
+
+    memcpy(self->sendbuf, &dnslen, 2);
+    memcpy(self->sendbuf + 2, buf, send);
+
+    PERF_LOCK(&self->lock);
+    n = SSL_write(self->ssl, self->sendbuf, send + 2);
+    if (n < 0) {
+        perf_log_warning("SSL_write(): %s", ERR_error_string(SSL_get_error(self->ssl, n), 0));
+        errno = EBADF;
+    }
+    PERF_UNLOCK(&self->lock);
+
+    if (n > 0 && n < send + 2) {
+        self->sending    = n;
+        sock->is_sending = true;
+        self->is_ready   = false;
+        errno            = EINPROGRESS;
+        return -1;
+    }
+
+    return n > 0 ? n - 2 : n;
+}
+
+static int perf__dot_close(struct perf_net_socket* sock)
+{
+    // TODO
+    return close(sock->fd);
+}
+
+static int perf__dot_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b)
+{
+    return sock_a->fd == sock_b->fd;
+}
+
+static int perf__dot_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
+{
+    if (self->is_ready) {
+        return 1;
+    }
+
+    int ret;
+
+    if (self->sending) {
+        uint16_t dnslen;
+        ssize_t  n;
+
+        memcpy(&dnslen, self->sendbuf, 2);
+        dnslen = ntohs(dnslen);
+
+        PERF_LOCK(&self->lock);
+        n = SSL_write(self->ssl, self->sendbuf + self->sending, dnslen + 2 - self->sending);
+        if (n < 1) {
+            if (n < 0) {
+                perf_log_warning("SSL_write(): %s", ERR_error_string(SSL_get_error(self->ssl, n), 0));
+                errno = EBADF;
+            }
+            PERF_UNLOCK(&self->lock);
+            return -1;
+        }
+        PERF_UNLOCK(&self->lock);
+
+        self->sending += n;
+        if (self->sending < dnslen + 2) {
+            errno = EINPROGRESS;
+            return -1;
+        }
+        self->sending    = 0;
+        sock->is_sending = false;
+        self->is_ready   = true;
+        return 1;
+    }
+
+    if (!self->is_conn_ready) {
+        switch (perf_os_waituntilanywritable(&sock, 1, pipe_fd, timeout)) {
+        case PERF_R_TIMEDOUT:
+            return -1;
+        case PERF_R_SUCCESS: {
+            int       error = 0;
+            socklen_t len   = (socklen_t)sizeof(error);
+
+            getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, (void*)&error, &len);
+            if (error != 0) {
+                if (error == EINPROGRESS
+#if EWOULDBLOCK != EAGAIN
+                    || error == EWOULDBLOCK
+#endif
+                    || error == EAGAIN) {
+                    return 0;
+                }
+                return -1;
+            }
+        }
+        }
+        self->is_conn_ready = true;
+    }
+
+    PERF_LOCK(&self->lock);
+    ret = SSL_connect(self->ssl);
+    if (!ret) {
+        perf_log_warning("SSL_connect(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
+        PERF_UNLOCK(&self->lock);
+        return -1;
+    }
+    if (ret < 0) {
+        int err = SSL_get_error(self->ssl, ret);
+        PERF_UNLOCK(&self->lock);
+        if (err == SSL_ERROR_WANT_READ || err == SSL_ERROR_WANT_WRITE) {
+            return 0;
+        }
+        perf_log_warning("SSL_connect(): %s", ERR_error_string(err, 0));
+        return -1;
+    }
+    self->is_ready = true;
+    PERF_UNLOCK(&self->lock);
+    return 1;
+}
+
+struct perf_net_socket* perf_net_dot_opensocket(const perf_sockaddr_t* server, const perf_sockaddr_t* local, size_t bufsize)
+{
+    struct perf__dot_socket* tmp = calloc(1, sizeof(struct perf__dot_socket)); // clang scan-build
+    struct perf_net_socket* sock = (struct perf_net_socket*)tmp;
+
+    int ret, flags;
+
+    if (!sock) {
+        perf_log_fatal("perf_net_dot_opensocket() out of memory");
+        return 0; // needed for clang scan build
+    }
+
+    sock->recv      = perf__dot_recv;
+    sock->sendto    = perf__dot_sendto;
+    sock->close     = perf__dot_close;
+    sock->sockeq    = perf__dot_sockeq;
+    sock->sockready = perf__dot_sockready;
+
+    PERF_MUTEX_INIT(&self->lock);
+    self->is_ready = true;
+
+    sock->fd = socket(server->sa.sa.sa_family, SOCK_STREAM, 0);
+    if (sock->fd == -1) {
+        char __s[256];
+        perf_log_fatal("socket: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (!ssl_ctx) {
+#ifdef HAVE_TLS_METHOD
+        if (!(ssl_ctx = SSL_CTX_new(TLS_method()))) {
+            perf_log_fatal("SSL_CTX_new(): %s", ERR_error_string(ERR_get_error(), 0));
+        }
+        if (!SSL_CTX_set_min_proto_version(ssl_ctx, TLS1_2_VERSION)) {
+            perf_log_fatal("SSL_CTX_set_min_proto_version(TLS1_2_VERSION): %s", ERR_error_string(ERR_get_error(), 0));
+        }
+#else
+        if (!(ssl_ctx = SSL_CTX_new(SSLv23_client_method()))) {
+            perf_log_fatal("SSL_CTX_new(): %s", ERR_error_string(ERR_get_error(), 0));
+        }
+#endif
+    }
+    if (!(self->ssl = SSL_new(ssl_ctx))) {
+        perf_log_fatal("SSL_new(): %s", ERR_error_string(ERR_get_error(), 0));
+    }
+    if (!(ret = SSL_set_fd(self->ssl, sock->fd))) {
+        perf_log_fatal("SSL_set_fd(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
+    }
+
+    if (server->sa.sa.sa_family == AF_INET6) {
+        int on = 1;
+
+        if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) == -1) {
+            perf_log_warning("setsockopt(IPV6_V6ONLY) failed");
+        }
+    }
+
+    if (bind(sock->fd, &local->sa.sa, local->length) == -1) {
+        char __s[256];
+        perf_log_fatal("bind: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (bufsize > 0) {
+        bufsize *= 1024;
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_RCVBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_RCVBUF) failed");
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_SNDBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_SNDBUF) failed");
+    }
+
+    flags = fcntl(sock->fd, F_GETFL, 0);
+    if (flags < 0)
+        perf_log_fatal("fcntl(F_GETFL)");
+    ret = fcntl(sock->fd, F_SETFL, flags | O_NONBLOCK);
+    if (ret < 0)
+        perf_log_fatal("fcntl(F_SETFL)");
+
+    if (connect(sock->fd, &server->sa.sa, server->length)) {
+        if (errno == EINPROGRESS) {
+            self->is_ready = false;
+        } else {
+            char __s[256];
+            perf_log_fatal("connect() failed: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+        }
+    }
+
+    return sock;
+}

--- a/src/net_tcp.c
+++ b/src/net_tcp.c
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2019-2021 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+
+#include "net.h"
+
+#include "log.h"
+#include "strerror.h"
+#include "os.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#define self ((struct perf__tcp_socket*)sock)
+
+struct perf__tcp_socket {
+    struct perf_net_socket base;
+
+    char   recvbuf[TCP_RECV_BUF_SIZE], sendbuf[TCP_SEND_BUF_SIZE];
+    size_t at, sending;
+    bool   is_ready;
+
+    int                     flags;
+    struct sockaddr_storage dest_addr;
+    socklen_t               addrlen;
+};
+
+static ssize_t perf__tcp_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags)
+{
+    ssize_t  n;
+    uint16_t dnslen, dnslen2;
+
+    if (!sock->have_more) {
+        n = recv(sock->fd, self->recvbuf + self->at, TCP_RECV_BUF_SIZE - self->at, flags);
+        if (n < 0) {
+            if (errno == ECONNRESET) {
+                // Treat connection reset like try again until reconnection features are in
+                errno = EAGAIN;
+            }
+            return n;
+        }
+        self->at += n;
+        if (self->at < 3) {
+            errno = EAGAIN;
+            return -1;
+        }
+    }
+
+    memcpy(&dnslen, self->recvbuf, 2);
+    dnslen = ntohs(dnslen);
+    if (self->at < dnslen + 2) {
+        errno = EAGAIN;
+        return -1;
+    }
+    memcpy(buf, self->recvbuf + 2, len < dnslen ? len : dnslen);
+    memmove(self->recvbuf, self->recvbuf + 2 + dnslen, self->at - 2 - dnslen);
+    self->at -= 2 + dnslen;
+
+    if (self->at > 2) {
+        memcpy(&dnslen2, self->recvbuf, 2);
+        dnslen2 = ntohs(dnslen2);
+        if (self->at >= dnslen2 + 2) {
+            sock->have_more = true;
+            return dnslen;
+        }
+    }
+
+    sock->have_more = false;
+    return dnslen;
+}
+
+static ssize_t perf__tcp_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    size_t send = len < TCP_SEND_BUF_SIZE - 2 ? len : (TCP_SEND_BUF_SIZE - 2);
+    // TODO: We only send what we can send, because we can't continue sending
+    uint16_t dnslen = htons(send);
+    ssize_t  n;
+
+    memcpy(self->sendbuf, &dnslen, 2);
+    memcpy(self->sendbuf + 2, buf, send);
+    n = sendto(sock->fd, self->sendbuf, send + 2, flags, dest_addr, addrlen);
+
+    if (n > 0 && n < send + 2) {
+        sock->is_sending = true;
+        self->sending    = n;
+        self->flags      = flags;
+        memcpy(&self->dest_addr, dest_addr, addrlen);
+        self->addrlen  = addrlen;
+        self->is_ready = false;
+        errno          = EINPROGRESS;
+        return -1;
+    }
+
+    return n > 0 ? n - 2 : n;
+}
+
+static int perf__tcp_close(struct perf_net_socket* sock)
+{
+    return close(sock->fd);
+}
+
+static int perf__tcp_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b)
+{
+    return sock_a->fd == sock_b->fd;
+}
+
+static int perf__tcp_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
+{
+    if (self->is_ready) {
+        return 1;
+    }
+
+    if (self->sending) {
+        uint16_t dnslen;
+        ssize_t  n;
+
+        memcpy(&dnslen, self->sendbuf, 2);
+        dnslen = ntohs(dnslen);
+        n      = sendto(sock->fd, self->sendbuf + self->sending, dnslen + 2 - self->sending, self->flags, (struct sockaddr*)&self->dest_addr, self->addrlen);
+        if (n < 1) {
+            return -1;
+        }
+        self->sending += n;
+        if (self->sending < dnslen + 2) {
+            errno = EINPROGRESS;
+            return -1;
+        }
+        self->sending    = 0;
+        sock->is_sending = false;
+        self->is_ready   = true;
+        return 1;
+    }
+
+    switch (perf_os_waituntilanywritable(&sock, 1, pipe_fd, timeout)) {
+    case PERF_R_TIMEDOUT:
+        return -1;
+    case PERF_R_SUCCESS: {
+        int       error = 0;
+        socklen_t len   = (socklen_t)sizeof(error);
+
+        getsockopt(sock->fd, SOL_SOCKET, SO_ERROR, (void*)&error, &len);
+        if (error != 0) {
+            if (error == EINPROGRESS
+#if EWOULDBLOCK != EAGAIN
+                || error == EWOULDBLOCK
+#endif
+                || error == EAGAIN) {
+                return 0;
+            }
+            return -1;
+        }
+        self->is_ready = true;
+        return 1;
+    }
+    default:
+        break;
+    }
+
+    return -1;
+}
+
+struct perf_net_socket* perf_net_tcp_opensocket(const perf_sockaddr_t* server, const perf_sockaddr_t* local, size_t bufsize)
+{
+    struct perf__tcp_socket* tmp = calloc(1, sizeof(struct perf__tcp_socket)); // clang scan-build
+    struct perf_net_socket* sock = (struct perf_net_socket*)tmp;
+
+    int ret, flags;
+
+    if (!sock) {
+        perf_log_fatal("perf_net_tcp_opensocket() out of memory");
+        return 0; // needed for clang scan build
+    }
+
+    sock->recv      = perf__tcp_recv;
+    sock->sendto    = perf__tcp_sendto;
+    sock->close     = perf__tcp_close;
+    sock->sockeq    = perf__tcp_sockeq;
+    sock->sockready = perf__tcp_sockready;
+
+    self->is_ready = true;
+
+    sock->fd = socket(server->sa.sa.sa_family, SOCK_STREAM, 0);
+    if (sock->fd == -1) {
+        char __s[256];
+        perf_log_fatal("socket: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (server->sa.sa.sa_family == AF_INET6) {
+        int on = 1;
+
+        if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) == -1) {
+            perf_log_warning("setsockopt(IPV6_V6ONLY) failed");
+        }
+    }
+
+    if (bind(sock->fd, &local->sa.sa, local->length) == -1) {
+        char __s[256];
+        perf_log_fatal("bind: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (bufsize > 0) {
+        bufsize *= 1024;
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_RCVBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_RCVBUF) failed");
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_SNDBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_SNDBUF) failed");
+    }
+
+    flags = fcntl(sock->fd, F_GETFL, 0);
+    if (flags < 0)
+        perf_log_fatal("fcntl(F_GETFL)");
+    ret = fcntl(sock->fd, F_SETFL, flags | O_NONBLOCK);
+    if (ret < 0)
+        perf_log_fatal("fcntl(F_SETFL)");
+
+    if (connect(sock->fd, &server->sa.sa, server->length)) {
+        if (errno == EINPROGRESS) {
+            self->is_ready = false;
+        } else {
+            char __s[256];
+            perf_log_fatal("connect() failed: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+        }
+    }
+
+    return sock;
+}

--- a/src/net_udp.c
+++ b/src/net_udp.c
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019-2021 OARC, Inc.
+ * Copyright 2017-2018 Akamai Technologies
+ * Copyright 2006-2016 Nominum, Inc.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+
+#include "net.h"
+
+#include "log.h"
+#include "strerror.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#define self ((struct perf__udp_socket*)sock)
+
+struct perf__udp_socket {
+    struct perf_net_socket base;
+};
+
+static ssize_t perf__udp_recv(struct perf_net_socket* sock, void* buf, size_t len, int flags)
+{
+    return recv(sock->fd, buf, len, flags);
+}
+
+static ssize_t perf__udp_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+{
+    return sendto(sock->fd, buf, len, flags, dest_addr, addrlen);
+}
+
+static int perf__udp_close(struct perf_net_socket* sock)
+{
+    return close(sock->fd);
+}
+
+static int perf__udp_sockeq(struct perf_net_socket* sock_a, struct perf_net_socket* sock_b)
+{
+    return sock_a->fd == sock_b->fd;
+}
+
+static int perf__udp_sockready(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
+{
+    return 1;
+}
+
+struct perf_net_socket* perf_net_udp_opensocket(const perf_sockaddr_t* server, const perf_sockaddr_t* local, size_t bufsize)
+{
+    struct perf__udp_socket* tmp = calloc(1, sizeof(struct perf__udp_socket)); // clang scan-build
+    struct perf_net_socket* sock = (struct perf_net_socket*)tmp;
+
+    int ret, flags;
+
+    if (!sock) {
+        perf_log_fatal("perf_net_udp_opensocket() out of memory");
+        return 0; // needed for clang scan build
+    }
+
+    sock->recv      = perf__udp_recv;
+    sock->sendto    = perf__udp_sendto;
+    sock->close     = perf__udp_close;
+    sock->sockeq    = perf__udp_sockeq;
+    sock->sockready = perf__udp_sockready;
+
+    sock->fd = socket(server->sa.sa.sa_family, SOCK_DGRAM, 0);
+    if (sock->fd == -1) {
+        char __s[256];
+        perf_log_fatal("socket: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (server->sa.sa.sa_family == AF_INET6) {
+        int on = 1;
+
+        if (setsockopt(sock->fd, IPPROTO_IPV6, IPV6_V6ONLY, &on, sizeof(on)) == -1) {
+            perf_log_warning("setsockopt(IPV6_V6ONLY) failed");
+        }
+    }
+
+    if (bind(sock->fd, &local->sa.sa, local->length) == -1) {
+        char __s[256];
+        perf_log_fatal("bind: %s", perf_strerror_r(errno, __s, sizeof(__s)));
+    }
+
+    if (bufsize > 0) {
+        bufsize *= 1024;
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_RCVBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_RCVBUF) failed");
+
+        ret = setsockopt(sock->fd, SOL_SOCKET, SO_SNDBUF,
+            &bufsize, sizeof(bufsize));
+        if (ret < 0)
+            perf_log_warning("setsockbuf(SO_SNDBUF) failed");
+    }
+
+    flags = fcntl(sock->fd, F_GETFL, 0);
+    if (flags < 0)
+        perf_log_fatal("fcntl(F_GETFL)");
+    ret = fcntl(sock->fd, F_SETFL, flags | O_NONBLOCK);
+    if (ret < 0)
+        perf_log_fatal("fcntl(F_SETFL)");
+
+    return sock;
+}

--- a/src/os.c
+++ b/src/os.c
@@ -61,11 +61,12 @@ void perf_os_handlesignal(int sig, void (*handler)(int))
 perf_result_t
 perf_os_waituntilreadable(struct perf_net_socket* sock, int pipe_fd, int64_t timeout)
 {
-    return perf_os_waituntilanyreadable(sock, 1, pipe_fd, timeout);
+    struct perf_net_socket* socks[] = { sock };
+    return perf_os_waituntilanyreadable(socks, 1, pipe_fd, timeout);
 }
 
 perf_result_t
-perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
+perf_os_waituntilanyreadable(struct perf_net_socket** socks, unsigned int nfds, int pipe_fd,
     int64_t timeout)
 {
     struct pollfd fds[nfds + 1];
@@ -73,10 +74,10 @@ perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, i
     int           to, n;
 
     for (i = 0; i < nfds; i++) {
-        if (socks[i].have_more)
+        if (socks[i]->have_more)
             return (PERF_R_SUCCESS);
 
-        fds[i].fd     = socks[i].fd;
+        fds[i].fd     = socks[i]->fd;
         fds[i].events = POLLIN;
     }
 
@@ -109,7 +110,7 @@ perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, i
 }
 
 perf_result_t
-perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
+perf_os_waituntilanywritable(struct perf_net_socket** socks, unsigned int nfds, int pipe_fd,
     int64_t timeout)
 {
     struct pollfd fds[nfds + 1];
@@ -117,7 +118,7 @@ perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, i
     int           to, n;
 
     for (i = 0; i < nfds; i++) {
-        fds[i].fd     = socks[i].fd;
+        fds[i].fd     = socks[i]->fd;
         fds[i].events = POLLOUT;
     }
 

--- a/src/os.h
+++ b/src/os.h
@@ -34,11 +34,11 @@ perf_result_t
 perf_os_waituntilreadable(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
 
 perf_result_t
-perf_os_waituntilanyreadable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
+perf_os_waituntilanyreadable(struct perf_net_socket** socks, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 
 perf_result_t
-perf_os_waituntilanywritable(struct perf_net_socket* socks, unsigned int nfds, int pipe_fd,
+perf_os_waituntilanywritable(struct perf_net_socket** socks, unsigned int nfds, int pipe_fd,
     int64_t timeout);
 
 #endif

--- a/src/resperf.1.in
+++ b/src/resperf.1.in
@@ -393,7 +393,7 @@ from standard input.
 \fB-M \fImode\fB\fR
 .br
 .RS
-Specifies the transport mode to use, "udp", "tcp" or "tls". Default is "udp".
+Specifies the transport mode to use, "udp", "tcp" or "dot". Default is "udp".
 .RE
 
 \fB-s \fIserver_addr\fB\fR
@@ -407,7 +407,7 @@ The default is the loopback address, 127.0.0.1.
 .br
 .RS
 Sets the port on which the DNS packets are sent. If not specified, the
-standard DNS port (udp/tcp 53, tls 853) is used.
+standard DNS port (udp/tcp 53, DoT 853) is used.
 .RE
 
 \fB-a \fIlocal_addr\fB\fR

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -16,7 +16,7 @@ grep -q "Queries sent: *4" test2.out
 ../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m tcp >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
-../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m tls >test2.out
+../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m dot >test2.out
 cat test2.out
 grep -q "Queries sent: *2" test2.out
 ../dnsperf -s $ip -d "$srcdir/datafile" -n 1 -m dot >test2.out
@@ -70,7 +70,7 @@ grep -q "Queries sent: *2" test2.out
 
 # Ignore failure until https://github.com/DNS-OARC/dnsperf/issues/88 is fixed
 # May work on slower systems
-../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M tls || true
+../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M dot || true
 
 done # for ip
 
@@ -78,7 +78,7 @@ done # for ip
 sleep 2
 pkill -KILL -u `id -u` dnsperf || true
 
-../dnsperf -s 127.66.66.66 -d "$srcdir/datafile" -vvvv -m tls -n 1 &
+../dnsperf -s 127.66.66.66 -d "$srcdir/datafile" -vvvv -m dot -n 1 &
 sleep 2
 pkill -KILL -u `id -u` dnsperf || true
 


### PR DESCRIPTION
- Refactor network code into callable functions within `perf_net_socket`
  - Split UDP, TCP and DoT code into separate modules
  - Always use `IPV6_V6ONLY` socket option
- Rename TLS/tls to DoT/dot
- `dnsperf`: Include port in "Sending to" output, use "[addr]:port" format for IPv6
- `perf_sockaddr_port()`: Fix return port in host format
- `perf_sockaddr_setport()`: Fix setting port in network format