### PR TITLE
stats

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -9,6 +9,7 @@ extraction:
         - pkg-config
         - libssl-dev
         - libldns-dev
+        - libck-dev
     configure:
       command:
         - ./autogen.sh

--- a/src/net.h
+++ b/src/net.h
@@ -53,7 +53,7 @@ enum perf_net_mode {
 struct perf_net_socket;
 
 typedef ssize_t (*perf_net_recv_t)(struct perf_net_socket* sock, void* buf, size_t len, int flags);
-typedef ssize_t (*perf_net_sendto_t)(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
+typedef ssize_t (*perf_net_sendto_t)(struct perf_net_socket* sock, uint16_t qid, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen);
 typedef int (*perf_net_close_t)(struct perf_net_socket* sock);
 typedef int (*perf_net_sockeq_t)(struct perf_net_socket* sock, struct perf_net_socket* other);
 
@@ -68,7 +68,19 @@ typedef int (*perf_net_sockready_t)(struct perf_net_socket* sock, int pipe_fd, i
 /* Indicates if there are more data to be read in buffers of the transport */
 typedef bool (*perf_net_have_more_t)(struct perf_net_socket* sock);
 
+/* Callback for when a query has been sent if it was delayed due to partily sent or reconnection */
+typedef void (*perf_net_sent_cb_t)(struct perf_net_socket* sock, uint16_t qid);
+
+typedef enum perf_socket_event {
+    perf_socket_event_connect,
+    perf_socket_event_reconnect
+} perf_socket_event_t;
+/* Callback for socket events related to connection oriented protocols, for statistics */
+typedef void (*perf_net_event_cb_t)(struct perf_net_socket* sock, perf_socket_event_t event, uint64_t elapsed_time);
+
 struct perf_net_socket {
+    void* data; /* user data */
+
     enum perf_net_mode   mode;
     perf_net_recv_t      recv;
     perf_net_sendto_t    sendto;
@@ -76,6 +88,16 @@ struct perf_net_socket {
     perf_net_sockeq_t    sockeq;
     perf_net_sockready_t sockready;
     perf_net_have_more_t have_more;
+
+    /*
+     * Not set by protocol, set by caller.
+     * May be 0 if caller don't care.
+     * MUST NOT be called from sendto(), only called if query is delayed in some way.
+     */
+    perf_net_sent_cb_t sent;
+
+    /* Used if caller want info on connection oriented events */
+    perf_net_event_cb_t event;
 
     /*
      * The system file descriptor that is used for transport, this is used
@@ -89,9 +111,9 @@ static inline ssize_t perf_net_recv(struct perf_net_socket* sock, void* buf, siz
     return sock->recv(sock, buf, len, flags);
 }
 
-static inline ssize_t perf_net_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+static inline ssize_t perf_net_sendto(struct perf_net_socket* sock, uint16_t qid, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
 {
-    return sock->sendto(sock, buf, len, flags, dest_addr, addrlen);
+    return sock->sendto(sock, qid, buf, len, flags, dest_addr, addrlen);
 }
 
 static inline int perf_net_close(struct perf_net_socket* sock)

--- a/src/net_udp.c
+++ b/src/net_udp.c
@@ -41,7 +41,7 @@ static ssize_t perf__udp_recv(struct perf_net_socket* sock, void* buf, size_t le
     return recv(sock->fd, buf, len, flags);
 }
 
-static ssize_t perf__udp_sendto(struct perf_net_socket* sock, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
+static ssize_t perf__udp_sendto(struct perf_net_socket* sock, uint16_t qid, const void* buf, size_t len, int flags, const struct sockaddr* dest_addr, socklen_t addrlen)
 {
     return sendto(sock->fd, buf, len, flags, dest_addr, addrlen);
 }


### PR DESCRIPTION
- `dnsperf`: Add statistics for reconnections and connection latency
- `net`
  - Add user data to socket structure
  - Add callback for when a query is sent
  - Add callback for socket events, connect and reconnect
- `net_dot`: Fix bug when sending from buffer
- `resperf`:
  - Add statistics for reconnections
  - Block SIGPIPE when lost connection
  - Add plot data for connections and connection latency
  - Fix error on socket readiness check
  - Do a socket ready check when trying to process responses to get faster progress on connections and reconnect