### PR TITLE
TYPEnnn

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -146,6 +146,17 @@ perf_result_t perf_qtype_fromstring(const char* str, size_t len, perf_buffer_t* 
 {
     const perf_qtype_t* q = qtype_table;
 
+    if (len > 4 && !strncasecmp(str, "TYPE", 4)) {
+        char*             endptr = 0;
+        unsigned long int u      = strtoul(str + 4, &endptr, 10);
+        if (endptr != str + len || u == ULONG_MAX || u > 65535) {
+            return PERF_R_FAILURE;
+        }
+
+        perf_buffer_putuint16(target, u);
+        return PERF_R_SUCCESS;
+    }
+
     while (q->type) {
         if (!strncasecmp(q->type, str, len)) {
             perf_buffer_putuint16(target, q->value);

--- a/src/gen-qtype.c.py
+++ b/src/gen-qtype.c.py
@@ -40,6 +40,8 @@ print("""/*
 const perf_qtype_t qtype_table[] = {""")
 
 for k, v in qtype.items():
+    if k == "*" or k == "Unassigned" or k == "Reserved":
+        continue
     print("    { \"%s\", %d }," % (k, v))
 
 print("""    { 0, 0 }

--- a/src/qtype.c
+++ b/src/qtype.c
@@ -75,7 +75,6 @@ const perf_qtype_t qtype_table[] = {
     { "NSEC3PARAM", 51 },
     { "TLSA", 52 },
     { "SMIMEA", 53 },
-    { "Unassigned", 54 },
     { "HIP", 55 },
     { "NINFO", 56 },
     { "RKEY", 57 },
@@ -104,7 +103,6 @@ const perf_qtype_t qtype_table[] = {
     { "AXFR", 252 },
     { "MAILB", 253 },
     { "MAILA", 254 },
-    { "*", 255 },
     { "URI", 256 },
     { "CAA", 257 },
     { "AVC", 258 },
@@ -112,6 +110,5 @@ const perf_qtype_t qtype_table[] = {
     { "AMTRELAY", 260 },
     { "TA", 32768 },
     { "DLV", 32769 },
-    { "Reserved", 65535 },
     { 0, 0 }
 };

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -6,4 +6,4 @@ CLEANFILES = test*.log test*.trs \
 TESTS = test1.sh test2.sh test3.sh test4.sh
 
 EXTRA_DIST = $(TESTS) \
-  datafile datafile2 updatefile datafile3 datafile4
+  datafile datafile2 updatefile datafile3 datafile4 datafile5

--- a/src/test/datafile5
+++ b/src/test/datafile5
@@ -1,0 +1,5 @@
+google.com TYPE0
+google.com TYPE1
+google.com TYPE28
+google.com TYPE99999999
+google.com TYPE99999999 ignored

--- a/src/test/test2.sh
+++ b/src/test/test2.sh
@@ -72,6 +72,12 @@ grep -q "Queries sent: *2" test2.out
 # May work on slower systems
 ../resperf -s $ip -m 1 -d "$srcdir/datafile2" -r 2 -c 2 -M dot || true
 
+# TYPE test
+../dnsperf -s $ip -d "$srcdir/datafile5" -n 1 -W >test2.out
+cat test2.out
+grep -q "Queries sent: *3" test2.out
+grep -q "Warning: invalid qtype: TYPE99999999" test2.out
+
 done # for ip
 
 ../dnsperf -s 127.66.66.66 -d "$srcdir/datafile" -vvvv -m tcp -n 1 &


### PR DESCRIPTION
- Fix #145:
  - `dns`: Add support for parsing `TYPEnnn`
  - `qtype`: Remove `*`, `Unassigned` and `Reserved` from generated table