### PR TITLE
reconnect

### DIFF
--- a/src/net.h
+++ b/src/net.h
@@ -58,9 +58,8 @@ typedef int (*perf_net_close_t)(struct perf_net_socket* sock);
 typedef int (*perf_net_sockeq_t)(struct perf_net_socket* sock, struct perf_net_socket* other);
 
 /* sockready return:
- * -1: An error occurred, see errno
- *   - EINPROGRESS: socket is still sending
- * 0: Socket is not ready, may still be connecting or negotiating
+ * -1: socket readiness timed out / canceled / interrupted or unknown error
+ * 0: Socket is not ready, may still be connecting, negotiating or sending
  * 1: Socket is ready and can be used for sending to
  */
 typedef int (*perf_net_sockready_t)(struct perf_net_socket* sock, int pipe_fd, int64_t timeout);
@@ -72,8 +71,10 @@ typedef bool (*perf_net_have_more_t)(struct perf_net_socket* sock);
 typedef void (*perf_net_sent_cb_t)(struct perf_net_socket* sock, uint16_t qid);
 
 typedef enum perf_socket_event {
-    perf_socket_event_connect,
-    perf_socket_event_reconnect
+    perf_socket_event_connecting,
+    perf_socket_event_connected,
+    perf_socket_event_reconnecting,
+    perf_socket_event_reconnected
 } perf_socket_event_t;
 /* Callback for socket events related to connection oriented protocols, for statistics */
 typedef void (*perf_net_event_cb_t)(struct perf_net_socket* sock, perf_socket_event_t event, uint64_t elapsed_time);

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -405,11 +405,18 @@ static void perf__net_event(struct perf_net_socket* sock, perf_socket_event_t ev
     ramp_bucket* b = find_bucket(time_now);
 
     switch (event) {
-    case perf_socket_event_reconnect:
-        num_reconnections++;
-    case perf_socket_event_connect:
+    case perf_socket_event_reconnected:
+    case perf_socket_event_connected:
         b->connections++;
         b->conn_latency_sum += elapsed_time / (double)MILLION;
+        break;
+
+    case perf_socket_event_reconnecting:
+        num_reconnections++;
+        break;
+
+    default:
+        break;
     }
 }
 


### PR DESCRIPTION
- `net`:
  - Rework return for `sockready()` to properly indicate when socket is not ready vs timed out or canceled
  - Split connect and reconnect events into connecting and connected
- `net_dot`:
  - `sendto()`: Fix issue with lost queries if socket was not ready
  - `sockready()`:
    - Reconnect on all send errors
    - Remove warnings on `SSL_connect()` and do reconnect instead
  - Count reconnecting events instead of reconnected, since connection can be closed during TLS negotiation
- `net_tcp`:
  - Add `recv_need_reconn` to signal from the receiving thread that the sending thread needs to reconnect
  - Remove unneeded `flags`, `dest_addr`, `addrlen`
  - `sockready()`:
    - Reconnect on all send errors
    - Do more sending and reconnecting on the same pass through the function
  - Count reconnecting events instead of reconnected, since connection can be closed before it's established