### PR TITLE
DoH concurrent streams

### DIFF
--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -171,6 +171,11 @@ test over a local Ethernet connection, it should be zero.
 If one or more packets has been dropped, there may be a problem with the
 network connection.
 In that case, the results should be considered suspect and the test repeated.
+.SS "Using DNS-over-HTTPS"
+When using DNS-over-HTTPS you must set the \fB-O doh\-uri=...\fR to something
+that works with the server you're sending to.
+Also note that the value for maximum outstanding queries will be used to
+control the maximum concurrent streams within the HTTP/2 connection.
 .SH OPTIONS
 
 \fB-a \fIlocal_addr\fR

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -520,6 +520,7 @@ setup(int argc, char** argv, config_t* config)
     if (doh_method) {
         perf_net_doh_parse_method(doh_method);
     }
+    perf_net_doh_set_max_concurrent_streams(config->max_outstanding);
 
     if (family != NULL)
         config->family = perf_net_parsefamily(family);

--- a/src/net.h
+++ b/src/net.h
@@ -171,5 +171,6 @@ struct perf_net_socket* perf_net_doh_opensocket(const perf_sockaddr_t*, const pe
 
 void perf_net_doh_parse_uri(const char*);
 void perf_net_doh_parse_method(const char*);
+void perf_net_doh_set_max_concurrent_streams(size_t);
 
 #endif

--- a/src/resperf.1.in
+++ b/src/resperf.1.in
@@ -415,6 +415,11 @@ itself and the server under test can sustain.
 Otherwise, the test is likely to be cut short as a result of either running
 out of query IDs (because of large numbers of dropped queries) or of
 \fBresperf\fR falling behind its transmission schedule.
+.SS "Using DNS-over-HTTPS"
+When using DNS-over-HTTPS you must set the \fB-O doh\-uri=...\fR to something
+that works with the server you're sending to.
+Also note that the value for maximum outstanding queries will be used to
+control the maximum concurrent streams within the HTTP/2 connection.
 .SH OPTIONS
 Because the \fBresperf\-report\fR script passes its command line options
 directly to the \fBresperf\fR programs, they both accept the same set of

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -362,6 +362,7 @@ static void setup(int argc, char** argv)
     if (doh_method) {
         perf_net_doh_parse_method(doh_method);
     }
+    perf_net_doh_set_max_concurrent_streams(max_outstanding);
 
     if (max_outstanding > nsocks * DEFAULT_MAX_OUTSTANDING)
         perf_log_fatal("number of outstanding packets (%u) must not "


### PR DESCRIPTION
- `doh`:
  - Use outstanding queries as concurrent streams limit
  - Fix return len from receiving which was showing incorrect response sizes