### PR TITLE
Net stats

### DIFF
--- a/src/net.c
+++ b/src/net.c
@@ -224,3 +224,33 @@ struct perf_net_socket* perf_net_opensocket(enum perf_net_mode mode, const perf_
 
     return 0;
 }
+
+void perf_net_stats_init(enum perf_net_mode mode)
+{
+    switch (mode) {
+    case sock_doh:
+        perf_net_doh_stats_init();
+    default:
+        break;
+    }
+}
+
+void perf_net_stats_compile(enum perf_net_mode mode, struct perf_net_socket* sock)
+{
+    switch (mode) {
+    case sock_doh:
+        perf_net_doh_stats_compile(sock);
+    default:
+        break;
+    }
+}
+
+void perf_net_stats_print(enum perf_net_mode mode)
+{
+    switch (mode) {
+    case sock_doh:
+        perf_net_doh_stats_print();
+    default:
+        break;
+    }
+}

--- a/src/net.h
+++ b/src/net.h
@@ -173,4 +173,11 @@ void perf_net_doh_parse_uri(const char*);
 void perf_net_doh_parse_method(const char*);
 void perf_net_doh_set_max_concurrent_streams(size_t);
 
+void perf_net_stats_init(enum perf_net_mode);
+void perf_net_stats_compile(enum perf_net_mode, struct perf_net_socket*);
+void perf_net_stats_print(enum perf_net_mode);
+void perf_net_doh_stats_init();
+void perf_net_doh_stats_compile(struct perf_net_socket*);
+void perf_net_doh_stats_print();
+
 #endif

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -249,8 +249,8 @@ static void setup(int argc, char** argv)
     unsigned int i;
     const char*  _mode           = 0;
     const char*  edns_option_str = NULL;
-    const char*  doh_uri         = 0;
-    const char*  doh_method      = 0;
+    const char*  doh_uri         = DEFAULT_DOH_URI;
+    const char*  doh_method      = DEFAULT_DOH_METHOD;
 
     sock_family     = AF_UNSPEC;
     server_port     = 0;
@@ -430,8 +430,10 @@ cleanup(void)
     unsigned int i;
 
     perf_datafile_close(&input);
-    for (i = 0; i < nsocks; i++)
+    for (i = 0; i < nsocks; i++) {
+        perf_net_stats_compile(mode, socks[i]);
         (void)perf_net_close(socks[i]);
+    }
     close(dummypipe[0]);
     close(dummypipe[1]);
 
@@ -545,6 +547,7 @@ print_statistics(void)
     }
     printf("  Maximum throughput:   %.6lf qps\n", max_throughput);
     printf("  Lost at that point:   %.2f%%\n", loss_at_max_throughput);
+    printf("\n");
 }
 
 /*
@@ -917,7 +920,9 @@ end_loop:
 
     fclose(plotf);
     print_statistics();
+    perf_net_stats_init(mode);
     cleanup();
+    perf_net_stats_print(mode);
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
     ERR_free_strings();
 #endif


### PR DESCRIPTION
- `net`: Add stats interface
- `doh`:
  - Fix default values for URI and method
  - Collect and print stats about HTTP/2 return codes