### PR TITLE
Queries per connection

### DIFF
--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -416,6 +416,22 @@ Following type are available.
 .br
 \fBunexpected\fR: Suppress messages about answers with an unexpected message ID
 .RE
+
+\fBnum-queries-per-conn=\fINUMBER\fR
+.br
+.RS
+This will limit the number of queries sent over a connection before
+triggering a re-connection. Once re-connected it will reset the counter and
+continue sending queries until the limit is reached again, triggering
+another re-connection and so on.
+Using this option will also enable counting number of responses received
+for each connection and once the limit is reached for sending queries it
+will wait until the same amount of responses has been received before
+re-connecting.
+Waiting for responses may timeout and the timeout used for this is the
+same as specified by \fB-t\fR.
+Note that this option is only useful for connection oriented protocols.
+.RE
 .SH "SEE ALSO"
 \fBresperf\fR(1)
 .SH AUTHOR

--- a/src/net.h
+++ b/src/net.h
@@ -80,6 +80,8 @@ typedef enum perf_socket_event {
 /* Callback for socket events related to connection oriented protocols, for statistics */
 typedef void (*perf_net_event_cb_t)(struct perf_net_socket* sock, perf_socket_event_t event, uint64_t elapsed_time);
 
+typedef void (*perf_net_num_queries_per_conn_t)(struct perf_net_socket* sock, size_t num_queries_per_conn, size_t timeout);
+
 struct perf_net_socket {
     void* data; /* user data */
 
@@ -90,6 +92,8 @@ struct perf_net_socket {
     perf_net_sockeq_t    sockeq;
     perf_net_sockready_t sockready;
     perf_net_have_more_t have_more;
+
+    perf_net_num_queries_per_conn_t num_queries_per_conn;
 
     /*
      * Not set by protocol, set by caller.

--- a/src/net_tcp.c
+++ b/src/net_tcp.c
@@ -80,13 +80,20 @@ struct perf__tcp_socket {
 
     uint64_t            conn_ts;
     perf_socket_event_t conn_event, conning_event;
+
+    size_t       num_queries_per_conn, nqpc_timeout;
+    unsigned int nqpc_sent, nqpc_recv;
+    uint64_t     nqpc_ts;
 };
 
 static int perf__tcp_connect(struct perf_net_socket* sock)
 {
     int fd;
 
-    self->is_ready = true;
+    self->is_ready  = true;
+    self->nqpc_sent = 0;
+    ck_pr_store_uint(&self->nqpc_recv, 0);
+    self->nqpc_ts = 0;
 
     fd = socket(self->server.sa.sa.sa_family, SOCK_STREAM, 0);
     if (fd == -1) {
@@ -192,6 +199,9 @@ static ssize_t perf__tcp_recv(struct perf_net_socket* sock, void* buf, size_t le
     memcpy(buf, self->recvbuf + 2, len < dnslen ? len : dnslen);
     memmove(self->recvbuf, self->recvbuf + 2 + dnslen, self->at - 2 - dnslen);
     self->at -= 2 + dnslen;
+    if (self->num_queries_per_conn) {
+        ck_pr_inc_uint(&self->nqpc_recv);
+    }
 
     if (self->at > 2) {
         memcpy(&dnslen2, self->recvbuf, 2);
@@ -251,6 +261,7 @@ static ssize_t perf__tcp_sendto(struct perf_net_socket* sock, uint16_t qid, cons
         errno            = EINPROGRESS;
         return -1;
     }
+    self->nqpc_sent++;
 
     return n - 2;
 }
@@ -302,6 +313,17 @@ static int perf__tcp_sockready(struct perf_net_socket* sock, int pipe_fd, int64_
             if (sock->sent) {
                 sock->sent(sock, self->qid);
             }
+            self->nqpc_sent++;
+        }
+        if (self->num_queries_per_conn && self->nqpc_sent >= self->num_queries_per_conn) {
+            if (!self->nqpc_ts) {
+                self->nqpc_ts = perf_get_time() + self->nqpc_timeout;
+            }
+            unsigned int r = ck_pr_load_uint(&self->nqpc_recv);
+            if (r >= self->nqpc_sent || perf_get_time() > self->nqpc_ts) {
+                self->need_reconnect = true;
+            }
+            return 0;
         }
         return 1;
     }
@@ -352,6 +374,7 @@ conn_cont:
             if (sock->sent) {
                 sock->sent(sock, self->qid);
             }
+            self->nqpc_sent++;
         }
         return 1;
     }
@@ -365,6 +388,12 @@ conn_cont:
 static bool perf__tcp_have_more(struct perf_net_socket* sock)
 {
     return self->have_more;
+}
+
+static void perf__tcp_num_queries_per_conn(struct perf_net_socket* sock, size_t num_queries_per_conn, size_t timeout)
+{
+    self->num_queries_per_conn = num_queries_per_conn;
+    self->nqpc_timeout         = timeout;
 }
 
 struct perf_net_socket* perf_net_tcp_opensocket(const perf_sockaddr_t* server, const perf_sockaddr_t* local, size_t bufsize, void* data, perf_net_sent_cb_t sent, perf_net_event_cb_t event)
@@ -383,6 +412,8 @@ struct perf_net_socket* perf_net_tcp_opensocket(const perf_sockaddr_t* server, c
     sock->sockeq    = perf__tcp_sockeq;
     sock->sockready = perf__tcp_sockready;
     sock->have_more = perf__tcp_have_more;
+
+    sock->num_queries_per_conn = perf__tcp_num_queries_per_conn;
 
     sock->data  = data;
     sock->sent  = sent;

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -255,6 +255,8 @@ static void setup(int argc, char** argv)
     const char*  doh_method      = DEFAULT_DOH_METHOD;
     const char*  local_suppress  = 0;
 
+    size_t num_queries_per_conn = 0;
+
     sock_family     = AF_UNSPEC;
     server_port     = 0;
     local_port      = DEFAULT_LOCAL_PORT;
@@ -337,6 +339,8 @@ static void setup(int argc, char** argv)
         "the HTTP method to use for DNS-over-HTTPS: GET or POST", DEFAULT_DOH_METHOD, &doh_method);
     perf_long_opt_add("suppress", perf_opt_string, "message[,message,...]",
         "suppress messages/warnings, see dnsperf(1) man-page for list of message types", NULL, &local_suppress);
+    perf_long_opt_add("num-queries-per-conn", perf_opt_uint, "queries",
+        "Number of queries to send per connection", NULL, &num_queries_per_conn);
 
     perf_opt_parse(argc, argv);
 
@@ -427,6 +431,9 @@ static void setup(int argc, char** argv)
         socks[i] = perf_net_opensocket(mode, &server_addr, &local_addr, i, bufsize, (void*)(intptr_t)i, perf__net_sent, perf__net_event);
         if (!socks[i]) {
             perf_log_fatal("perf_net_opensocket(): no socket returned, out of memory?");
+        }
+        if (num_queries_per_conn && socks[i]->num_queries_per_conn) {
+            socks[i]->num_queries_per_conn(socks[i], num_queries_per_conn, query_timeout);
         }
     }
 }


### PR DESCRIPTION
- Fix #195: Add `-O num-queries-per-conn=<num>` to control number of queries sent over a connection before re-connecting