### PR TITLE
Receive socket error handling

### DIFF
--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -924,7 +924,10 @@ recv_one(threadinfo_t* tinfo, int which_sock,
     }
     if (!n) {
         // Treat connection closed like try again until reconnection features are in
-        *saved_errnop = EAGAIN;
+        if (!*saved_errnop) {
+            // only set this if there was no error before to allow above error check to overwrite EAGAIN
+            *saved_errnop = EAGAIN;
+        }
         return false;
     }
     recvd->sock           = tinfo->socks[which_sock];
@@ -1010,8 +1013,6 @@ do_recv(void* arg)
                     break;
                 }
                 bit_set(socketbits, current_socket);
-                if (saved_errno != EAGAIN)
-                    break;
             }
             if (j == tinfo->nsocks)
                 break;


### PR DESCRIPTION
- `dnsperf`: Issue #208:
  - `recv_one()`: Fix handling errno, only store EAGAIN if no other error has been received
  - `do_recv()`: Don't break on error as it will count it as a received message