### PR TITLE
Bad file descriptor

### DIFF
--- a/src/net_doh.c
+++ b/src/net_doh.c
@@ -324,6 +324,8 @@ static ssize_t perf__doh_recv(struct perf_net_socket* sock, void* buf, size_t le
                 return -1;
             case SSL_ERROR_SYSCALL:
                 switch (errno) {
+                case EBADF:
+                    // treat this as a retry, can happen if sendto is reconnecting
                 case ECONNREFUSED:
                 case ECONNRESET:
                 case ENOTCONN:

--- a/src/net_dot.c
+++ b/src/net_dot.c
@@ -177,6 +177,8 @@ static ssize_t perf__dot_recv(struct perf_net_socket* sock, void* buf, size_t le
                 break;
             case SSL_ERROR_SYSCALL:
                 switch (errno) {
+                case EBADF:
+                    // treat this as a retry, can happen if sendto is reconnecting
                 case ECONNREFUSED:
                 case ECONNRESET:
                 case ENOTCONN:

--- a/src/net_tcp.c
+++ b/src/net_tcp.c
@@ -171,6 +171,8 @@ static ssize_t perf__tcp_recv(struct perf_net_socket* sock, void* buf, size_t le
             return 0;
         } else if (n < 0) {
             switch (errno) {
+            case EBADF:
+                // treat this as a retry, can happen if sendto is reconnecting
             case ECONNREFUSED:
             case ECONNRESET:
             case ENOTCONN:


### PR DESCRIPTION
- `net`: Fix #208: Treat `EBADF` as `EAGAIN` for stateful connections, receive thread might read from a closed socket if send thread is reconnecting