### PR TITLE
Suppress unexpected

### DIFF
--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -1186,11 +1186,13 @@ do_recv(void* arg)
                 perf_log_warning("received short response");
                 continue;
             }
-            if (recvd[i].unexpected && !tinfo->config->suppress.unexpected) {
-                perf_log_warning("received a response with an "
-                                 "unexpected (maybe timed out) "
-                                 "id: %u",
-                    recvd[i].qid);
+            if (recvd[i].unexpected) {
+                if (!tinfo->config->suppress.unexpected) {
+                    perf_log_warning("received a response with an "
+                                     "unexpected (maybe timed out) "
+                                     "id: %u",
+                        recvd[i].qid);
+                }
                 continue;
             }
             latency = recvd[i].when - recvd[i].sent;


### PR DESCRIPTION
- `dnsperf`: Fix #222: don't process unexpected message if the message is suppressed