### PR TITLE
Opt arg

### DIFF
--- a/src/opt.c
+++ b/src/opt.c
@@ -239,6 +239,7 @@ static int perf_opt_long_parse(char* optarg)
     char*   arg;
 
     if ((arg = strchr(optarg, '='))) {
+        arg++;
         optlen = arg - optarg;
         if (optlen < 1) {
             return -1;
@@ -246,7 +247,6 @@ static int perf_opt_long_parse(char* optarg)
     } else {
         optlen = strlen(optarg);
     }
-    arg++;
 
     long_opt_t* opt = longopts;
     while (opt) {

--- a/src/test/test1.sh
+++ b/src/test/test1.sh
@@ -2,3 +2,8 @@
 
 ../dnsperf -h
 ../resperf -h
+
+! ../dnsperf -O suppress
+! ../dnsperf -O suppress=
+! ../resperf -O suppress
+! ../resperf -O suppress=


### PR DESCRIPTION
- `opt`: `perf_opt_long_parse()`: Fix `arg` and `optlen` handling for `-O opt=value`
- Add tests for some invalid `-O`