### PR TITLE
Long opt

### DIFF
--- a/src/opt.c
+++ b/src/opt.c
@@ -239,9 +239,9 @@ static int perf_opt_long_parse(char* optarg)
     char*   arg;
 
     if ((arg = strchr(optarg, '='))) {
+        optlen = arg - optarg;
         arg++;
-        optlen = strlen(arg);
-        if (optlen < 1) {
+        if (optlen < 1 || !strlen(arg)) {
             return -1;
         }
     } else {

--- a/src/test/test1.sh
+++ b/src/test/test1.sh
@@ -10,3 +10,5 @@
 
 # test for broken long opt in v2.11.0
 ../dnsperf -O suppress=test 2>&1 |grep -q "unknown message type to suppress: test"
+# ...and in v2.11.1, issue #234
+../dnsperf -O doh-uri=https://blahblah.com/dns-query -O suppress=timeouts -h


### PR DESCRIPTION
- `opt`: Fix #234: correctly calculate option length and check if argument contains anything