### PR TITLE
Add TLS Server Name Indication extension support

### DIFF
--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -441,6 +441,13 @@ The HTTP method to use when querying with DNS-over-HTTPS, default is GET.
 Available methods are: GET, POST.
 .RE
 
+\fBtls-sni=\fISERVER_NAME\fR
+.br
+.RS
+The TLS Server Name Indication (SNI) to use when querying with DNS-over-HTTPS or DNS-over-TLS,
+defaults to leaving out the SNI extension in the client hello.
+.RE
+
 \fBsuppress=\fIMESSAGE[,MESSAGE,...]\fR
 .br
 .RS

--- a/src/dnsperf.1.in
+++ b/src/dnsperf.1.in
@@ -444,7 +444,7 @@ Available methods are: GET, POST.
 \fBtls-sni=\fISERVER_NAME\fR
 .br
 .RS
-The TLS Server Name Indication (SNI) to use when querying with DNS-over-HTTPS or DNS-over-TLS,
+The Server Name Indication (SNI) to use for TLS connections (such as DNS-over-TLS or DNS-over-HTTPS),
 defaults to leaving out the SNI extension in the client hello.
 .RE
 

--- a/src/dnsperf.c
+++ b/src/dnsperf.c
@@ -587,6 +587,7 @@ setup(int argc, char** argv, config_t* config)
     const char* doh_uri        = DEFAULT_DOH_URI;
     const char* doh_method     = DEFAULT_DOH_METHOD;
     const char* local_suppress = 0;
+    const char* tls_sni        = 0;
 
     memset(config, 0, sizeof(*config));
     config->argc = argc;
@@ -681,6 +682,8 @@ setup(int argc, char** argv, config_t* config)
 #endif
     perf_long_opt_add("qps-threshold-wait", perf_opt_zpint, "microseconds",
         "minimum threshold for enabling wait in rate limiting", stringify(config->qps_threshold_wait), &config->qps_threshold_wait);
+    perf_long_opt_add("tls-sni", perf_opt_string, "tls_sni",
+        "the TLS SNI to use for TLS connections", NULL, &tls_sni);
 
     bool log_stdout = false;
     perf_opt_add('W', perf_opt_boolean, NULL, "log warnings and errors to stdout instead of stderr", NULL, &log_stdout);
@@ -708,6 +711,10 @@ setup(int argc, char** argv, config_t* config)
             server_port = DEFAULT_SERVER_PORT;
             break;
         }
+    }
+
+    if (tls_sni) {
+        perf_net_tls_sni = tls_sni;
     }
 
     if (doh_uri) {

--- a/src/net.c
+++ b/src/net.c
@@ -31,6 +31,8 @@
 #include <netdb.h>
 #include <arpa/inet.h>
 
+const char* perf_net_tls_sni = 0;
+
 enum perf_net_mode perf_net_parsemode(const char* mode)
 {
     if (!strcmp(mode, "udp")) {

--- a/src/net.h
+++ b/src/net.h
@@ -175,8 +175,6 @@ struct perf_net_socket* perf_net_doh_opensocket(const perf_sockaddr_t*, const pe
 
 void perf_net_doh_parse_uri(const char*);
 void perf_net_doh_parse_method(const char*);
-void perf_net_doh_set_sni(const char*);
-void perf_net_dot_set_sni(const char*);
 void perf_net_doh_set_max_concurrent_streams(size_t);
 
 void perf_net_stats_init(enum perf_net_mode);
@@ -185,5 +183,7 @@ void perf_net_stats_print(enum perf_net_mode);
 void perf_net_doh_stats_init();
 void perf_net_doh_stats_compile(struct perf_net_socket*);
 void perf_net_doh_stats_print();
+
+extern const char* perf_net_tls_sni;
 
 #endif

--- a/src/net.h
+++ b/src/net.h
@@ -175,6 +175,8 @@ struct perf_net_socket* perf_net_doh_opensocket(const perf_sockaddr_t*, const pe
 
 void perf_net_doh_parse_uri(const char*);
 void perf_net_doh_parse_method(const char*);
+void perf_net_doh_set_sni(const char*);
+void perf_net_dot_set_sni(const char*);
 void perf_net_doh_set_max_concurrent_streams(size_t);
 
 void perf_net_stats_init(enum perf_net_mode);

--- a/src/net_doh.c
+++ b/src/net_doh.c
@@ -38,7 +38,6 @@
 #include <errno.h>
 #include <assert.h>
 #include <fcntl.h>
-#include <stdbool.h>
 #include <unistd.h>
 #include <openssl/err.h>
 #include <sys/socket.h>
@@ -58,7 +57,6 @@ enum perf_doh_method {
     doh_method_post
 };
 static enum perf_doh_method doh_method      = doh_method_get;
-static const char*          doh_sni         = NULL;
 static size_t               doh_max_concurr = 100;
 
 #define self ((struct perf__doh_socket*)sock)
@@ -154,11 +152,6 @@ void perf_net_doh_parse_method(const char* method)
     exit(1);
 }
 
-void perf_net_doh_set_sni(const char* sni)
-{
-    doh_sni = sni;
-}
-
 void perf_net_doh_set_max_concurrent_streams(size_t max_concurr)
 {
     doh_max_concurr = max_concurr;
@@ -191,11 +184,11 @@ static void perf__doh_connect(struct perf_net_socket* sock)
     if (!(self->ssl = SSL_new(ssl_ctx))) {
         perf_log_fatal("SSL_new(): %s", ERR_error_string(ERR_get_error(), 0));
     }
+    if (perf_net_tls_sni && !(ret = SSL_set_tlsext_host_name(self->ssl, perf_net_tls_sni))) {
+        perf_log_fatal("SSL_set_tlsext_host_name(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
+    }
     if (!(ret = SSL_set_fd(self->ssl, sock->fd))) {
         perf_log_fatal("SSL_set_fd(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
-    }
-    if (doh_sni && !(ret = SSL_set_tlsext_host_name(self->ssl, doh_sni))) {
-        perf_log_fatal("SSL_set_tlsext_host_name(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
     }
 
     if (self->server.sa.sa.sa_family == AF_INET6) {

--- a/src/net_doh.c
+++ b/src/net_doh.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <assert.h>
 #include <fcntl.h>
+#include <stdbool.h>
 #include <unistd.h>
 #include <openssl/err.h>
 #include <sys/socket.h>
@@ -57,6 +58,7 @@ enum perf_doh_method {
     doh_method_post
 };
 static enum perf_doh_method doh_method      = doh_method_get;
+static const char*          doh_sni         = NULL;
 static size_t               doh_max_concurr = 100;
 
 #define self ((struct perf__doh_socket*)sock)
@@ -152,6 +154,11 @@ void perf_net_doh_parse_method(const char* method)
     exit(1);
 }
 
+void perf_net_doh_set_sni(const char* sni)
+{
+    doh_sni = sni;
+}
+
 void perf_net_doh_set_max_concurrent_streams(size_t max_concurr)
 {
     doh_max_concurr = max_concurr;
@@ -186,6 +193,9 @@ static void perf__doh_connect(struct perf_net_socket* sock)
     }
     if (!(ret = SSL_set_fd(self->ssl, sock->fd))) {
         perf_log_fatal("SSL_set_fd(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
+    }
+    if (doh_sni && !(ret = SSL_set_tlsext_host_name(self->ssl, doh_sni))) {
+        perf_log_fatal("SSL_set_tlsext_host_name(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
     }
 
     if (self->server.sa.sa.sa_family == AF_INET6) {

--- a/src/net_dot.c
+++ b/src/net_dot.c
@@ -28,7 +28,6 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <stdbool.h>
 #include <unistd.h>
 #include <openssl/err.h>
 #include <sys/socket.h>
@@ -36,7 +35,6 @@
 #include <ck_pr.h>
 
 static SSL_CTX* ssl_ctx = 0;
-static const char* dot_sni = NULL;
 
 #define self ((struct perf__dot_socket*)sock)
 
@@ -63,11 +61,6 @@ struct perf__dot_socket {
     uint64_t     nqpc_ts;
 };
 
-void perf_net_dot_set_sni(const char* sni)
-{
-    dot_sni = sni;
-}
-
 static void perf__dot_connect(struct perf_net_socket* sock)
 {
     int ret;
@@ -89,11 +82,11 @@ static void perf__dot_connect(struct perf_net_socket* sock)
     if (!(self->ssl = SSL_new(ssl_ctx))) {
         perf_log_fatal("SSL_new(): %s", ERR_error_string(ERR_get_error(), 0));
     }
+    if (perf_net_tls_sni && !(ret = SSL_set_tlsext_host_name(self->ssl, perf_net_tls_sni))) {
+        perf_log_fatal("SSL_set_tlsext_host_name(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
+    }
     if (!(ret = SSL_set_fd(self->ssl, sock->fd))) {
         perf_log_fatal("SSL_set_fd(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
-    }
-    if (dot_sni && !(ret = SSL_set_tlsext_host_name(self->ssl, dot_sni))) {
-        perf_log_fatal("SSL_set_tlsext_host_name(): %s", ERR_error_string(SSL_get_error(self->ssl, ret), 0));
     }
 
     if (self->server.sa.sa.sa_family == AF_INET6) {

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -253,6 +253,7 @@ static void setup(int argc, char** argv)
     const char*  edns_option_str = NULL;
     const char*  doh_uri         = DEFAULT_DOH_URI;
     const char*  doh_method      = DEFAULT_DOH_METHOD;
+    const char*  tls_sni         = NULL;
     const char*  local_suppress  = 0;
 
     size_t num_queries_per_conn = 0;
@@ -337,6 +338,8 @@ static void setup(int argc, char** argv)
         "the URI to use for DNS-over-HTTPS", DEFAULT_DOH_URI, &doh_uri);
     perf_long_opt_add("doh-method", perf_opt_string, "doh_method",
         "the HTTP method to use for DNS-over-HTTPS: GET or POST", DEFAULT_DOH_METHOD, &doh_method);
+    perf_long_opt_add("tls-sni", perf_opt_string, "tls_sni",
+        "set the TLS Server Name Indication extension in the client hello for DoH and DoT", NULL, &tls_sni);
     perf_long_opt_add("suppress", perf_opt_string, "message[,message,...]",
         "suppress messages/warnings, see dnsperf(1) man-page for list of message types", NULL, &local_suppress);
     perf_long_opt_add("num-queries-per-conn", perf_opt_uint, "queries",
@@ -372,6 +375,10 @@ static void setup(int argc, char** argv)
     }
     if (doh_method) {
         perf_net_doh_parse_method(doh_method);
+    }
+    if (tls_sni && strlen(tls_sni)) {
+        perf_net_doh_set_sni(tls_sni);
+        perf_net_dot_set_sni(tls_sni);
     }
     perf_net_doh_set_max_concurrent_streams(max_outstanding);
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -253,7 +253,7 @@ static void setup(int argc, char** argv)
     const char*  edns_option_str = NULL;
     const char*  doh_uri         = DEFAULT_DOH_URI;
     const char*  doh_method      = DEFAULT_DOH_METHOD;
-    const char*  tls_sni         = NULL;
+    const char*  tls_sni         = 0;
     const char*  local_suppress  = 0;
 
     size_t num_queries_per_conn = 0;
@@ -339,7 +339,7 @@ static void setup(int argc, char** argv)
     perf_long_opt_add("doh-method", perf_opt_string, "doh_method",
         "the HTTP method to use for DNS-over-HTTPS: GET or POST", DEFAULT_DOH_METHOD, &doh_method);
     perf_long_opt_add("tls-sni", perf_opt_string, "tls_sni",
-        "set the TLS Server Name Indication extension in the client hello for DoH and DoT", NULL, &tls_sni);
+        "the TLS SNI to use for TLS connections", NULL, &tls_sni);
     perf_long_opt_add("suppress", perf_opt_string, "message[,message,...]",
         "suppress messages/warnings, see dnsperf(1) man-page for list of message types", NULL, &local_suppress);
     perf_long_opt_add("num-queries-per-conn", perf_opt_uint, "queries",
@@ -370,15 +370,15 @@ static void setup(int argc, char** argv)
         }
     }
 
+    if (tls_sni) {
+        perf_net_tls_sni = tls_sni;
+    }
+
     if (doh_uri) {
         perf_net_doh_parse_uri(doh_uri);
     }
     if (doh_method) {
         perf_net_doh_parse_method(doh_method);
-    }
-    if (tls_sni && strlen(tls_sni)) {
-        perf_net_doh_set_sni(tls_sni);
-        perf_net_dot_set_sni(tls_sni);
     }
     perf_net_doh_set_max_concurrent_streams(max_outstanding);
 


### PR DESCRIPTION
Support for the TLS SNI extension when querying with DNS-over-HTTPS or DNS-over-TLS.

Otherwise some TLS servers (like cloudflare gateway) respond with 'Handshake Failure' instead of the server hello. When passing the '-v' flag to resperf, it logs: `Warning: failed to send packet: socket 0 not ready`.

This is solved with a new command line argument: `-O tls-sni=example.org`, as I tested on AlmaLinux for both DoT and DoH.

TODO:

- [ ] implement it for dnsperf too (instead of only for resperf)