### PR TITLE
fix gcov

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,7 +16,8 @@
 # limitations under the License.
 
 MAINTAINERCLEANFILES = $(srcdir)/Makefile.in $(srcdir)/config.h.in
-CLEANFILES = dnsperf.1 resperf.1 *.gcda *.gcno *.gcov
+CLEANFILES = dnsperf.1 resperf.1 *.gcda *.gcno *.gcov \
+  */*.gcda */*.gcno */*.gcov
 
 SUBDIRS = test
 

--- a/src/resperf.c
+++ b/src/resperf.c
@@ -914,6 +914,7 @@ end_loop:
     if (!plotf) {
         char __s[256];
         perf_log_fatal("could not open %s: %s", plotfile, perf_strerror_r(errno, __s, sizeof(__s)));
+        return 0; // fix clang scan-build
     }
 
     /* Print column headers */


### PR DESCRIPTION
- Fix for gcov, was not removing old profile data from subdirectories
- `resperf`: Fix scan-build inability to know fatal ends the program